### PR TITLE
Press escape to cancel connecting to a server

### DIFF
--- a/ui/transition_connecting.rml
+++ b/ui/transition_connecting.rml
@@ -22,7 +22,9 @@
 			}
 		</style>
 	</head>
-	<body id="connecting" nohide>
+	<body id="connecting"
+	      onKeyDown="if event.parameters['key_identifier'] == rocket.key_identifier.ESCAPE then Events.pushevent('exec disconnect', event) end"
+	      nohide>
 		<div>
 			<connecting/>
 		</div>


### PR DESCRIPTION
The implementation in the engine [1] stopped working since the ui key
catcher is now enabled during connection.

[1] https://github.com/DaemonEngine/Daemon/blob/b17dd395a247ad0e0a53435d13ce73efb0863cb8/src/engine/client/cl_keys.cpp#L602