### PR TITLE
Use attack3 for barb/spit, drop useitem, fix Unvanquished#1184, ref Unvanquished#1182, Unvanquished #544

### DIFF
--- a/default.cfg
+++ b/default.cfg
@@ -38,8 +38,8 @@ teambind humans     SHIFT  +sprint
 teambind humans     hw:q   +activate // use armory
 teambind humans     CTRL   +movedown // crouch
 
-teambind aliens     CTRL   +movedown // wallwalk
 teambind aliens     hw:q   +activate // evolve
+teambind aliens     CTRL   +movedown // wallwalk
 
 //
 // MISC

--- a/default.cfg
+++ b/default.cfg
@@ -10,7 +10,6 @@ unbindall
 
 bind  mwheelup      weapprev
 bind  mwheeldown    weapnext
-teambind humans MOUSE3 +useitem
 
 //
 // CHARACTER CONTROLS
@@ -18,6 +17,7 @@ teambind humans MOUSE3 +useitem
 
 bind  MOUSE1        +attack
 bind  MOUSE2        +attack2
+bind  MOUSE3        +attack3
 
 bind  hw:w          +forward
 bind  hw:a          +moveleft
@@ -27,7 +27,6 @@ bind  hw:d          +moveright
 bind  ALT           +speed // slow walk
 bind  SPACE         +moveup
 bind  hw:c          +taunt
-
 
 teambind humans     hw:g   itemact grenade
 teambind humans     hw:f   itemact medkit
@@ -40,7 +39,6 @@ teambind humans     hw:e   "modcase alt \"/deconstruct marked\" /deconstruct"
 
 teambind aliens     CTRL   +movedown // wallwalk
 teambind aliens     hw:q   +activate // evolve
-teambind aliens     MOUSE3 +useitem // shoot barb/spit
 teambind aliens     hw:e   "modcase alt \"/deconstruct marked\" /deconstruct"
 
 //

--- a/default.cfg
+++ b/default.cfg
@@ -28,6 +28,8 @@ bind  ALT           +speed // slow walk
 bind  SPACE         +moveup
 bind  hw:c          +taunt
 
+bind  hw:e          "modcase alt \"deconstruct marked\" deconstruct"
+
 teambind humans     hw:g   itemact grenade
 teambind humans     hw:f   itemact medkit
 teambind humans     hw:1   itemtoggle blaster
@@ -35,11 +37,9 @@ teambind humans     hw:r   reload
 teambind humans     SHIFT  +sprint
 teambind humans     hw:q   +activate // use armory
 teambind humans     CTRL   +movedown // crouch
-teambind humans     hw:e   "modcase alt \"deconstruct marked\" deconstruct"
 
 teambind aliens     CTRL   +movedown // wallwalk
 teambind aliens     hw:q   +activate // evolve
-teambind aliens     hw:e   "modcase alt \"deconstruct marked\" deconstruct"
 
 //
 // MISC

--- a/default.cfg
+++ b/default.cfg
@@ -28,7 +28,7 @@ bind  ALT           +speed // slow walk
 bind  SPACE         +moveup
 bind  hw:c          +taunt
 
-bind  hw:e          "modcase alt \"deconstruct marked\" deconstruct"
+bind  hw:e          +deconstruct
 
 teambind humans     hw:g   itemact grenade
 teambind humans     hw:f   itemact medkit

--- a/default.cfg
+++ b/default.cfg
@@ -35,11 +35,11 @@ teambind humans     hw:r   reload
 teambind humans     SHIFT  +sprint
 teambind humans     hw:q   +activate // use armory
 teambind humans     CTRL   +movedown // crouch
-teambind humans     hw:e   "modcase alt \"/deconstruct marked\" /deconstruct"
+teambind humans     hw:e   "modcase alt \"deconstruct marked\" deconstruct"
 
 teambind aliens     CTRL   +movedown // wallwalk
 teambind aliens     hw:q   +activate // evolve
-teambind aliens     hw:e   "modcase alt \"/deconstruct marked\" /deconstruct"
+teambind aliens     hw:e   "modcase alt \"deconstruct marked\" deconstruct"
 
 //
 // MISC
@@ -68,4 +68,4 @@ bind  F2            "vote no"
 bind  F3            "teamvote yes"
 bind  F4            "teamvote no"
 
-bind  F11           modcase shift /screenshotPNG /screenshotJPEG
+bind  F11           modcase shift screenshotPNG screenshotJPEG

--- a/ui/hud_basics.rml
+++ b/ui/hud_basics.rml
@@ -33,7 +33,7 @@
 			bottom: 21%;
 			text-align: left;
 			width: 40%;
-			left: .5em;
+			left: 5em;
 		}
 
 		region.crosshair {

--- a/ui/options_keys.rml
+++ b/ui/options_keys.rml
@@ -143,7 +143,7 @@
 					<keybind cmd="modcase shift screenshotPNG screenshotJPEG" />
 					<p>Screenshot:</p>
 				</row>
-				<p> Hold shift when taking a screenshot to capture a PNG, otherwise shots are taken in JPEG. </p>
+				<p>Hold SHIFT when taking a screenshot to capture a PNG, otherwise shots are taken in JPEG.</p>
 			</panel>
 			<tab>Quake-look</tab>
 			<panel>

--- a/ui/options_keys.rml
+++ b/ui/options_keys.rml
@@ -41,7 +41,6 @@
 					<p>Jump:</p>
 				</row>
 				<row>
-
 					<keybind cmd="+movedown" team="humans" />
 					<p>Crouch:</p>
 				</row>
@@ -49,7 +48,6 @@
 					<keybind cmd="+movedown" team="aliens" />
 					<p>Wallwalk:</p>
 				</row>
-
 			</panel>
 			<tab>Abilities</tab>
 			<panel>
@@ -62,7 +60,7 @@
 					<p>Secondary Attack:</p>
 				</row>
 				<row>
-					<keybind cmd="+useitem" team="aliens" />
+					<keybind cmd="+attack3" team="aliens" />
 					<p>Shoot Barb:</p>
 				</row>
 				<row>
@@ -75,7 +73,7 @@
 				</row>
 				<row>
 					<keybind cmd="itemact grenade" team="humans" />
-					<p>Throw grenade</p>
+					<p>Throw grenade:</p>
 				</row>
 				<row>
 					<keybind cmd="+activate" team="humans" />

--- a/ui/options_keys.rml
+++ b/ui/options_keys.rml
@@ -64,16 +64,16 @@
 					<p>Shoot Barb:</p>
 				</row>
 				<row>
+					<keybind cmd="itemact grenade" team="humans" />
+					<p>Throw grenade:</p>
+				</row>
+				<row>
 					<keybind cmd="reload" team="humans" />
 					<p>Reload:</p>
 				</row>
 				<row>
 					<keybind cmd="itemact medkit" team="humans" />
 					<p>Use Medkit:</p>
-				</row>
-				<row>
-					<keybind cmd="itemact grenade" team="humans" />
-					<p>Throw grenade:</p>
 				</row>
 				<row>
 					<keybind cmd="+activate" team="humans" />

--- a/ui/options_keys.rml
+++ b/ui/options_keys.rml
@@ -126,10 +126,10 @@
 					<p>Show Scores:</p>
 				</row>
 				<row>
-					<keybind cmd='modcase alt "deconstruct marked" deconstruct' />
+					<keybind cmd='+deconstruct' />
 					<p>Mark structure for replacement:</p>
 				</row>
-				<p>Hold ALT to deconstruct marked structure.
+				<p>Hold the key to deconstruct structure.
 				</p>
 				<row>
 					<keybind cmd='beaconMenu' />

--- a/ui/options_keys.rml
+++ b/ui/options_keys.rml
@@ -126,7 +126,7 @@
 					<p>Show Scores:</p>
 				</row>
 				<row>
-					<keybind cmd='modcase alt "/deconstruct marked" /deconstruct' />
+					<keybind cmd='modcase alt "deconstruct marked" deconstruct' />
 					<p>Mark structure for replacement:</p>
 				</row>
 				<p>Hold ALT to deconstruct marked structure.
@@ -140,7 +140,7 @@
 					<p>Toggle console:</p>
 				</row>
 				<row>
-					<keybind cmd="modcase shift /screenshotPNG /screenshotJPEG" />
+					<keybind cmd="modcase shift screenshotPNG screenshotJPEG" />
 					<p>Screenshot:</p>
 				</row>
 				<p> Hold shift when taking a screenshot to capture a PNG, otherwise shots are taken in JPEG. </p>


### PR DESCRIPTION
Counterpart to https://github.com/Unvanquished/Unvanquished/pull/1182
Fixes https://github.com/Unvanquished/Unvanquished/issues/1184

Use `attack3` for barb/spit/grenade, drop `useitem`, ref Unvanquished#1182, Unvanquished #544

See https://github.com/Unvanquished/Unvanquished/issues/1180
See https://github.com/Unvanquished/Unvanquished/issues/544