### PR TITLE
ui: add a message saying the game is in development

### DIFF
--- a/ui/menu_ingame.rml
+++ b/ui/menu_ingame.rml
@@ -12,6 +12,8 @@
 		<img class="circles" src="/ui/assets/background/circles2" />
 		<img class="black2" src="/ui/assets/background/black2" />
 
+		<div style="position: absolute; bottom: 1em; left: 1em; color: rgba(255, 0, 0, 100); font-size: 80%;">This game version is part of the Unvanquished beta development program, game experience and depicted assets may not represent the final game.</div>
+
 		<sidebar>
 				<!-- HACK: Using shared/window.rml as a stylesheet rather than a template -->
 				<window id="innersidebar" class="innersidebar" >

--- a/ui/menu_main.rml
+++ b/ui/menu_main.rml
@@ -16,6 +16,8 @@
 		<img class="black2" src="/ui/assets/background/black2" />
 		<img class="logo" src="/ui/assets/logos/fuzzy_blue" />
 
+		<div style="position: absolute; bottom: 1em; left: 1em; color: rgba(255, 0, 0, 100); font-size: 80%;">This game version is part of the Unvanquished beta development program, game experience and depicted assets may not represent the final game.</div>
+
 		<sidebar>
 				<!-- HACK: Add some extra spacing atop the main menu -->
 				<hackyspacer />


### PR DESCRIPTION
Add a message saying the game is in early access, idea from a comment in #14.

We were afraid to make the game much known because people may not understand the game is not finished and may build bad reputation that will stick based on wrong assumptions or things that we already know ourselves they must be fixed. But time has passed and players are now more accustomed to the “early access” thing that is now well established [see wikipedia article](https://en.wikipedia.org/wiki/Early_access).

The idea is to display a disclaimer on the bottom left of the game screen so it would be obvious for anyone that the game they play is not a complete release. This way we can be a bit braver to advertise the game.

Also, because the human people is a weird kind of social animal with irrational behaviour, it may also increases the proud of owning this game, the need to share this proud and attract interest in it. :sweat_smile:

The message is displayed on the bottom left of the screen when the menu is displayed (not when playing game of course):

[![disclaimer](https://dl.illwieckz.net/b/unvanquished/wip/disclaimer/unvanquished_2020-05-04_023350_000.jpg)](https://dl.illwieckz.net/b/unvanquished/wip/disclaimer/unvanquished_2020-05-04_023350_000.jpg)

[![disclaimer](https://dl.illwieckz.net/b/unvanquished/wip/disclaimer/unvanquished_2020-05-04_023440_000.jpg)](https://dl.illwieckz.net/b/unvanquished/wip/disclaimer/unvanquished_2020-05-04_023440_000.jpg)
