### PR TITLE
Circle menu rewrite (number key support)

### DIFF
--- a/ui/alien_build.rml
+++ b/ui/alien_build.rml
@@ -6,7 +6,6 @@
 <style>
 body
 {
-	padding-top:10%;
 	width:100%;
 	height:100%;
 	background:#00000066;
@@ -86,30 +85,53 @@ body
 tabs {
 	display: none;
 }
-div.infobox {
-	position: absolute;
-	top: 40%;
-	right: 10%;
-	float: right;
-	width: 45%;
-	height: 50%;
-}
 </style>
 <script src="lua/util.lua" />
+<script>
+	function ClearAlienBuildableInfo(document)
+		document:GetElementById("b_name").inner_rml = ""
+		document:GetElementById("b_price").inner_rml = ""
+		document:GetElementById("b_desc").inner_rml = ""
+	end
+	function AlienBuildableClick(idx, event)
+		CDataSource.Build("alienBuildList", "default")
+		local data = CDataSource.Read("alienBuildList", "default", "availability,cmdName")[idx]
+		if data[1] == "available" then
+			Cmd.exec("build " .. data[2])
+			Events.pushevent("hide alien_build", event)
+		end
+	end
+	function AlienBuildableHover(document, idx)
+		buildable = alien_buildables[idx]
+		document:GetElementById("b_name").inner_rml = buildable[2]
+		document:GetElementById("b_price").inner_rml = buildable[4]
+		document:GetElementById("b_desc").inner_rml = buildable[3]
+	end
+	function BuildAlienBuildMenu(document)
+		ClearAlienBuildableInfo(document)
+		CDataSource.Build("alienBuildList", "default")
+		alien_buildables = CDataSource.Read("alienBuildList", "default", "icon,name,description,cost,availability")
+		local circlemenu = document:GetElementById("alienBuildMenu")
+		circlemenu.inner_rml = CirclemenuSkeleton(#alien_buildables)
+		for i = 1,#alien_buildables do
+			circlemenu.child_nodes[i].inner_rml = string.format(
+				'<button class=%s onclick="AlienBuildableClick(%d,event)" onmouseover="AlienBuildableHover(document,%d)">%s<img src="/%s"/></button>',
+				alien_buildables[i][5], i, i, AvailabilityIcon(alien_buildables[i][5]), alien_buildables[i][1])
+		end
+	end
+</script>
 </head>
-<body id="alien_build" class="circlemenu alien" onKeyDown="detectEscape(event, document)" onShow='Events.pushevent("buildDS alienBuildList default; buildDS alienBuildList upgrades", event)'>
-<div id="foo">
+<body id="alien_build" class="circlemenu alien" onkeydown="detectEscape(event, document)" onshow="BuildAlienBuildMenu(document)">
 <tabset class="circlemenu">
 <tab></tab>
 <panel>
-<circlemenu id="default" source="alienBuildList.default" fields="num" formatter="CMAlienBuildables" onCancel="Events.pushevent('hide alien_build', event)"/>
+<div class="circlemenu-circle" id="alienBuildMenu"/>
 <div class="infobox">
-<h2><datasource_single source="alienBuildList.default" fields="name" targetid="default" /></h2>
-<p class="text">Price: <datasource_single source="alienBuildList.default" fields="cost" targetid="default" /><br/>
-<datasource_single source="alienBuildList.default" fields="description" targetid="default" /></p>
+<h2 id="b_name"></h2>
+<p class="text">Price: <span id="b_price" /><br/>
+<span id="b_desc" /></p>
 </div>
 </panel>
 </tabset>
-</div>
 </body>
 </rml>

--- a/ui/alien_build.rml
+++ b/ui/alien_build.rml
@@ -94,6 +94,7 @@ tabs {
 		document:GetElementById("b_desc").inner_rml = ""
 	end
 	function AlienBuildableClick(idx, event)
+		if idx > #alien_buildables then return end
 		CDataSource.Build("alienBuildList", "default")
 		local data = CDataSource.Read("alienBuildList", "default", "availability,cmdName")[idx]
 		if data[1] == "available" then
@@ -121,7 +122,7 @@ tabs {
 	end
 </script>
 </head>
-<body id="alien_build" class="circlemenu alien" onkeydown="detectEscape(event, document)" onshow="BuildAlienBuildMenu(document)">
+<body id="alien_build" class="circlemenu alien" onkeydown="CirclemenuHandleKey(event, document, AlienBuildableClick)" onshow="BuildAlienBuildMenu(document)">
 <tabset class="circlemenu">
 <tab></tab>
 <panel>

--- a/ui/alien_build.rml
+++ b/ui/alien_build.rml
@@ -119,6 +119,7 @@ tabs {
 				'<button class=%s onclick="AlienBuildableClick(%d,event)" onmouseover="AlienBuildableHover(document,%d)">%s<img src="/%s"/></button>',
 				alien_buildables[i][5], i, i, AvailabilityIcon(alien_buildables[i][5]), alien_buildables[i][1])
 		end
+		document:GetElementById("keyboardHints").inner_rml = CirclemenuKeyboardHints(#alien_buildables)
 	end
 </script>
 </head>
@@ -126,6 +127,7 @@ tabs {
 <tabset class="circlemenu">
 <tab></tab>
 <panel>
+<div class="circlemenu-circle" id="keyboardHints"/>
 <div class="circlemenu-circle" id="alienBuildMenu"/>
 <div class="infobox">
 <h2 id="b_name"></h2>

--- a/ui/alien_evo.rml
+++ b/ui/alien_evo.rml
@@ -6,7 +6,6 @@
 <style>
 body
 {
-	padding-top:10%;
 	width:100%;
 	height:100%;
 	background:#00000066;
@@ -65,10 +64,6 @@ body
 	opacity:.7;
 }
 
-.circlemenu button.doublegranger {
-	display: none;
-}
-
 .circlemenu button{
 	position:relative;
 	icon-color-multiplier: red;
@@ -91,29 +86,59 @@ body
 tabs {
 	display: none;
 }
-div.infobox {
-	position: absolute;
-	top: 40%;
-	right: 10%;
-	float: right;
-	width: 45%;
-	height: 50%;
-}
 </style>
 <script src="lua/util.lua" />
+<script>
+	function ClearEvolveInfo(document)
+		document:GetElementById("e_name").inner_rml = ""
+		document:GetElementById("e_price").inner_rml = ""
+		document:GetElementById("e_desc").inner_rml = ""
+	end
+	function EvolutionClick(idx, event)
+		CDataSource.Build("alienEvolveList", "default")
+		local data = CDataSource.Read("alienEvolveList", "default", "availability,cmdName")[idx]
+		if data[1] == "available" then
+			Cmd.exec("class " .. data[2])
+			Events.pushevent("hide alien_evo", event)
+		end
+	end
+	function EvolutionHover(document, idx)
+		local evolution = evolutions[idx]
+		document:GetElementById("e_name").inner_rml = evolution[2]
+		document:GetElementById("e_price").inner_rml = evolution[5]
+		document:GetElementById("e_desc").inner_rml = evolution[3]
+	end
+	function BuildEvolveMenu(document)
+		ClearEvolveInfo(document)
+		CDataSource.Build("alienEvolveList", "default")
+		evolutions = CDataSource.Read("alienEvolveList", "default", "icon,name,description,availability,price,visible")
+		local button_to_index = {}
+		for i = 1,#evolutions do
+			if evolutions[i][6] == "true" then
+				table.insert(button_to_index, i)
+			end
+		end
+		local circlemenu = document:GetElementById("evolveMenu")
+		circlemenu.inner_rml = CirclemenuSkeleton(#button_to_index)
+		for b = 1,#button_to_index do
+			i = button_to_index[b]
+			circlemenu.child_nodes[b].inner_rml = string.format(
+				'<button class=%s onclick="EvolutionClick(%d,event)" onmouseover="EvolutionHover(document,%d)">%s<img src="/%s"/></button>',
+				evolutions[i][4], i, i, AvailabilityIcon(evolutions[i][4]), evolutions[i][1])
+		end
+	end
+</script>
 </head>
-<body id="alien_evo" class="circlemenu alien" onKeyDown="detectEscape(event, document)" onShow='Events.pushevent("buildDS alienEvolveList default; buildDS alienEvolveList upgrades", event)'>
-<div id="foo">
+<body id="alien_evo" class="circlemenu alien" onkeydown="detectEscape(event, document)" onshow="BuildEvolveMenu(document)">
 <tabset class="circlemenu">
 <tab></tab>
 <panel>
-<circlemenu id="default" source="alienEvolveList.default" fields="num" formatter="CMAlienEvolve" onCancel="Events.pushevent('hide alien_evo', event)"/>
+<div class="circlemenu-circle" id="evolveMenu"/>
 <div class="infobox">
-<h2><datasource_single source="alienEvolveList.default" fields="name" targetid="default" /></h2>
-<p class="text"><!--Price: --><datasource_single source="alienEvolveList.default" fields="price" targetid="default" /> morph points<br /><datasource_single source="alienEvolveList.default" fields="description" targetid="default" /></p>
+<h2 id="e_name"></h2>
+<p class="text"><!--Price: --><span id="e_price"/> morph points<br /><span id="e_desc"/></p>
 </div>
 </panel>
 </tabset>
-</div>
 </body>
 </rml>

--- a/ui/alien_evo.rml
+++ b/ui/alien_evo.rml
@@ -95,6 +95,8 @@ tabs {
 		document:GetElementById("e_desc").inner_rml = ""
 	end
 	function EvolutionClick(idx, event)
+		idx = button_to_index[idx]
+		if idx == nil then return end
 		CDataSource.Build("alienEvolveList", "default")
 		local data = CDataSource.Read("alienEvolveList", "default", "availability,cmdName")[idx]
 		if data[1] == "available" then
@@ -112,7 +114,7 @@ tabs {
 		ClearEvolveInfo(document)
 		CDataSource.Build("alienEvolveList", "default")
 		evolutions = CDataSource.Read("alienEvolveList", "default", "icon,name,description,availability,price,visible")
-		local button_to_index = {}
+		button_to_index = {}
 		for i = 1,#evolutions do
 			if evolutions[i][6] == "true" then
 				table.insert(button_to_index, i)
@@ -124,12 +126,12 @@ tabs {
 			i = button_to_index[b]
 			circlemenu.child_nodes[b].inner_rml = string.format(
 				'<button class=%s onclick="EvolutionClick(%d,event)" onmouseover="EvolutionHover(document,%d)">%s<img src="/%s"/></button>',
-				evolutions[i][4], i, i, AvailabilityIcon(evolutions[i][4]), evolutions[i][1])
+				evolutions[i][4], b, i, AvailabilityIcon(evolutions[i][4]), evolutions[i][1])
 		end
 	end
 </script>
 </head>
-<body id="alien_evo" class="circlemenu alien" onkeydown="detectEscape(event, document)" onshow="BuildEvolveMenu(document)">
+<body id="alien_evo" class="circlemenu alien" onkeydown="CirclemenuHandleKey(event, document, EvolutionClick)" onshow="BuildEvolveMenu(document)">
 <tabset class="circlemenu">
 <tab></tab>
 <panel>

--- a/ui/alien_evo.rml
+++ b/ui/alien_evo.rml
@@ -128,6 +128,7 @@ tabs {
 				'<button class=%s onclick="EvolutionClick(%d,event)" onmouseover="EvolutionHover(document,%d)">%s<img src="/%s"/></button>',
 				evolutions[i][4], b, i, AvailabilityIcon(evolutions[i][4]), evolutions[i][1])
 		end
+		document:GetElementById("keyboardHints").inner_rml = CirclemenuKeyboardHints(#button_to_index)
 	end
 </script>
 </head>
@@ -135,6 +136,7 @@ tabs {
 <tabset class="circlemenu">
 <tab></tab>
 <panel>
+<div class="circlemenu-circle" id="keyboardHints"/>
 <div class="circlemenu-circle" id="evolveMenu"/>
 <div class="infobox">
 <h2 id="e_name"></h2>

--- a/ui/human_build.rml
+++ b/ui/human_build.rml
@@ -119,6 +119,7 @@ tabs {
 				'<button class=%s onclick="HumanBuildableClick(%d,event)" onmouseover="HumanBuildableHover(document,%d)">%s<img src="/%s"/></button>',
 				human_buildables[i][5], i, i, AvailabilityIcon(human_buildables[i][5]), human_buildables[i][1])
 		end
+		document:GetElementById("keyboardHints").inner_rml = CirclemenuKeyboardHints(#human_buildables)
 	end
 </script>
 </head>
@@ -126,6 +127,7 @@ tabs {
 <tabset class="circlemenu">
 <tab></tab>
 <panel>
+<div class="circlemenu-circle" id="keyboardHints"/>
 <div class="circlemenu-circle" id="humanBuildMenu"/>
 <div class="infobox">
 <h2 id="b_name"></h2>

--- a/ui/human_build.rml
+++ b/ui/human_build.rml
@@ -6,7 +6,6 @@
 <style>
 body
 {
-	padding-top:10%;
 	width:100%;
 	height:100%;
 	background:#00000066;
@@ -86,30 +85,53 @@ body
 tabs {
 	display: none;
 }
-div.infobox {
-	position: absolute;
-	top: 40%;
-	right: 10%;
-	float: right;
-	width: 45%;
-	height: 50%;
-}
 </style>
 <script src="lua/util.lua" />
+<script>
+	function ClearHumanBuildableInfo(document)
+		document:GetElementById("b_name").inner_rml = ""
+		document:GetElementById("b_price").inner_rml = ""
+		document:GetElementById("b_desc").inner_rml = ""
+	end
+	function HumanBuildableClick(idx, event)
+		CDataSource.Build("humanBuildList", "default")
+		local data = CDataSource.Read("humanBuildList", "default", "availability,cmdName")[idx]
+		if data[1] == "available" then
+			Cmd.exec("build " .. data[2])
+			Events.pushevent("hide human_build", event)
+		end
+	end
+	function HumanBuildableHover(document, idx)
+		local buildable = human_buildables[idx]
+		document:GetElementById("b_name").inner_rml = buildable[2]
+		document:GetElementById("b_price").inner_rml = buildable[4]
+		document:GetElementById("b_desc").inner_rml = buildable[3]
+	end
+	function BuildHumanBuildMenu(document)
+		ClearHumanBuildableInfo(document)
+		CDataSource.Build("humanBuildList", "default")
+		human_buildables = CDataSource.Read("humanBuildList", "default", "icon,name,description,cost,availability")
+		local circlemenu = document:GetElementById("humanBuildMenu")
+		circlemenu.inner_rml = CirclemenuSkeleton(#human_buildables)
+		for i = 1,#human_buildables do
+			circlemenu.child_nodes[i].inner_rml = string.format(
+				'<button class=%s onclick="HumanBuildableClick(%d,event)" onmouseover="HumanBuildableHover(document,%d)">%s<img src="/%s"/></button>',
+				human_buildables[i][5], i, i, AvailabilityIcon(human_buildables[i][5]), human_buildables[i][1])
+		end
+	end
+</script>
 </head>
-<body id="human_build" class="circlemenu human" onKeyDown="detectEscape(event, document)" onShow='Events.pushevent("buildDS humanBuildList default; buildDS humanBuildList upgrades", event)'>
-<div id="foo">
+<body id="human_build" class="circlemenu human" onkeydown="detectEscape(event, document)" onshow="BuildHumanBuildMenu(document)">
 <tabset class="circlemenu">
 <tab></tab>
 <panel>
-<circlemenu id="default" source="humanBuildList.default" fields="num" formatter="CMHumanBuildables" onCancel="Events.pushevent('hide human_build', event)"/>
+<div class="circlemenu-circle" id="humanBuildMenu"/>
 <div class="infobox">
-<h2><datasource_single source="humanBuildList.default" fields="name" targetid="default" /></h2>
-<p class="text">Price: <datasource_single source="humanBuildList.default" fields="cost" targetid="default" /><br/>
-<datasource_single source="humanBuildList.default" fields="description" targetid="default" /></p>
+<h2 id="b_name"></h2>
+<p class="text">Price: <span id="b_price" /><br/>
+<span id="b_desc" /></p>
 </div>
 </panel>
 </tabset>
-</div>
 </body>
 </rml>

--- a/ui/human_build.rml
+++ b/ui/human_build.rml
@@ -94,6 +94,7 @@ tabs {
 		document:GetElementById("b_desc").inner_rml = ""
 	end
 	function HumanBuildableClick(idx, event)
+		if idx > #human_buildables then return end
 		CDataSource.Build("humanBuildList", "default")
 		local data = CDataSource.Read("humanBuildList", "default", "availability,cmdName")[idx]
 		if data[1] == "available" then
@@ -121,7 +122,7 @@ tabs {
 	end
 </script>
 </head>
-<body id="human_build" class="circlemenu human" onkeydown="detectEscape(event, document)" onshow="BuildHumanBuildMenu(document)">
+<body id="human_build" class="circlemenu human" onkeydown="CirclemenuHandleKey(event, document, HumanBuildableClick)" onshow="BuildHumanBuildMenu(document)">
 <tabset class="circlemenu">
 <tab></tab>
 <panel>

--- a/ui/human_buy.rml
+++ b/ui/human_buy.rml
@@ -87,6 +87,7 @@
 		</style>
 		<script>
 			function WeaponClick(idx)
+				if idx > #weapons then return end
 				-- Query again in case credits/momentum changed
 				CDataSource.Build("armouryBuyList", "weapons")
 				local data = CDataSource.Read("armouryBuyList", "weapons", "availability,cmdName")[idx]
@@ -126,6 +127,7 @@
 				end
 			end
 			function UpgradeClick(idx)
+				if idx > #upgrades then return end
 				-- Query again in case credits/momentum changed
 				CDataSource.Build("armouryBuyList", "upgrades")
 				local data = CDataSource.Read("armouryBuyList", "upgrades", "availability,cmdName")[idx]
@@ -158,12 +160,17 @@
 						upgrades[i][5], i, i, AvailabilityIcon(upgrades[i][5]), upgrades[i][1])
 				end
 			end
+			function HumanBuyHandleKey(event, document)
+				local tabset = Element.As.ElementTabSet(document:GetElementById("tabset"))
+				local handler = ({[0]=WeaponClick, [1]=UpgradeClick})[tabset.active_tab]
+				CirclemenuHandleKey(event, document, handler)
+			end
 		</script>
 	</head>
-	<body id="human_buy" class="circlemenu human" onkeydown="detectEscape(event, document)"
+	<body id="human_buy" class="circlemenu human" onkeydown="HumanBuyHandleKey(event, document)"
 	 onshow="WeaponClear(document) UpgradeClear(document) BuildWeaponMenu(document) BuildUpgradeMenu(document)"
 	 onrefreshdata="BuildWeaponMenu(document) BuildUpgradeMenu(document)">
-	<tabset class="circlemenu">
+	<tabset class="circlemenu" id="tabset">
 		<tab onclick="WeaponClear(document) BuildWeaponMenu(document)">Weapons</tab>
 		<panel>
 		<div class="circlemenu-circle" id="weapons"/>

--- a/ui/human_buy.rml
+++ b/ui/human_buy.rml
@@ -6,7 +6,6 @@
 		<style>
 			body
 			{
-				padding-top:10%;
 				width:100%;
 				height:100%;
 				background:#00000066;
@@ -85,44 +84,107 @@
 .circlemenu button.active .sell{
 	display:none;
 }
-
-div.infobox {
-	position: absolute;
-	top: 40%;
-	right: 10%;
-	float: right;
-	width: 45%;
-	height: 50%;
-}
-
-
 		</style>
+		<script>
+			function WeaponClick(idx)
+				-- Query again in case credits/momentum changed
+				CDataSource.Build("armouryBuyList", "weapons")
+				local data = CDataSource.Read("armouryBuyList", "weapons", "availability,cmdName")[idx]
+				if data[1] == "available" then
+					Cmd.exec("buy +" .. data[2])
+				elseif data[1] == "active" then
+					Cmd.exec("sell " .. data[2])
+				end
+			end
+			function WeaponClear(document)
+				document:GetElementById("w_name").inner_rml = ""
+				document:GetElementById("w_price").inner_rml = ""
+				document:GetElementById("w_rate").style.width = "0"
+				document:GetElementById("w_range").style.width = "0"
+				document:GetElementById("w_damage").style.width = "0"
+				document:GetElementById("w_description").inner_rml = ""
+			end
+			function WeaponHover(document, idx)
+				WeaponClear(document)
+				local data = weapons[idx]
+				document:GetElementById("w_name").inner_rml = data[2]
+				document:GetElementById("w_price").inner_rml = data[4]
+				document:GetElementById("w_rate").style.width = data[6] .. '%'
+				document:GetElementById("w_range").style.width = data[7] .. '%'
+				document:GetElementById("w_damage").style.width = data[8] .. '%'
+				document:GetElementById("w_description").inner_rml = data[3]
+			end
+			function BuildWeaponMenu(document)
+				CDataSource.Build("armouryBuyList", "weapons")
+				weapons = CDataSource.Read("armouryBuyList", "weapons", "icon,name,description,price,availability,rate,range,damage")
+				local circlemenu = document:GetElementById("weapons")
+				circlemenu.inner_rml = CirclemenuSkeleton(#weapons)
+				for i=1,#weapons do
+					circlemenu.child_nodes[i].inner_rml = string.format(
+						'<button class="%s" onclick="WeaponClick(%d)" onmouseover="WeaponHover(document,%d)">%s<img src="/%s"/></button>',
+						weapons[i][5], i, i, AvailabilityIcon(weapons[i][5]), weapons[i][1])
+				end
+			end
+			function UpgradeClick(idx)
+				-- Query again in case credits/momentum changed
+				CDataSource.Build("armouryBuyList", "upgrades")
+				local data = CDataSource.Read("armouryBuyList", "upgrades", "availability,cmdName")[idx]
+				if data[1] == "available" then
+					Cmd.exec("buy +" .. data[2])
+				elseif data[1] == "active" then
+					Cmd.exec("sell " .. data[2])
+				end
+			end
+			function UpgradeClear(document)
+				document:GetElementById("u_name").inner_rml = ""
+				document:GetElementById("u_price").inner_rml = ""
+				document:GetElementById("u_description").inner_rml = ""
+			end
+			function UpgradeHover(document, idx)
+				UpgradeClear(document)
+				local data = upgrades[idx]
+				document:GetElementById("u_name").inner_rml = data[2]
+				document:GetElementById("u_price").inner_rml = data[4]
+				document:GetElementById("u_description").inner_rml = data[3]
+			end
+			function BuildUpgradeMenu(document)
+				CDataSource.Build("armouryBuyList", "upgrades")
+				upgrades = CDataSource.Read("armouryBuyList", "upgrades", "icon,name,description,price,availability")
+				local circlemenu = document:GetElementById("upgrades")
+				circlemenu.inner_rml = CirclemenuSkeleton(#upgrades)
+				for i=1,#upgrades do
+					circlemenu.child_nodes[i].inner_rml = string.format(
+						'<button class="%s" onclick="UpgradeClick(%d)" onmouseover="UpgradeHover(document,%d)">%s<img src="/%s"/></button>',
+						upgrades[i][5], i, i, AvailabilityIcon(upgrades[i][5]), upgrades[i][1])
+				end
+			end
+		</script>
 	</head>
-	<body id="human_buy" class="circlemenu human" onKeyDown="detectEscape(event, document)" onShow='Events.pushevent("buildDS armouryBuyList weapons; buildDS armouryBuyList upgrades", event)'>
-	<div id="foo">
+	<body id="human_buy" class="circlemenu human" onkeydown="detectEscape(event, document)"
+	 onshow="WeaponClear(document) UpgradeClear(document) BuildWeaponMenu(document) BuildUpgradeMenu(document)"
+	 onrefreshdata="BuildWeaponMenu(document) BuildUpgradeMenu(document)">
 	<tabset class="circlemenu">
-		<tab>Weapons</tab>
+		<tab onclick="WeaponClear(document) BuildWeaponMenu(document)">Weapons</tab>
 		<panel>
-		<circlemenu id="weapons" source="armouryBuyList.weapons" fields="num" formatter="CMArmouryBuyWeapons" onCancel="Events.pushevent('hide human_buy', event)"/>
+		<div class="circlemenu-circle" id="weapons"/>
 			<div class="infobox">
-			<h2><datasource_single source="armouryBuyList.weapons" fields="name" targetid="weapons" /></h2>
-			<p><div class="attr">Price:</div><div class="bar"><datasource_single source="armouryBuyList.weapons" fields="price" targetid="weapons" /></div></p>
-			<p><div class="attr">Range:</div><div class="bar"><datasource_single source="armouryBuyList.weapons" fields="num" formatter="GWeaponRange" targetid="weapons" /></div></p>
-			<p><div class="attr">Damage:</div><div class="bar"><datasource_single source="armouryBuyList.weapons" fields="num" formatter="GWeaponDamage" targetid="weapons" /></div></p>
-			<p><div class="attr">Fire Rate:</div><div class="bar"><datasource_single source="armouryBuyList.weapons" fields="num" formatter="GWeaponRateOfFire" targetid="weapons" /></div></p>
-			<p class="text"><datasource_single source="armouryBuyList.weapons" fields="description" targetid="weapons" /></p>
+			<h2 id="w_name"></h2>
+			<p><div class="attr">Price:</div><div class="bar"><div id="w_price"></div></div></p>
+			<p><div class="attr">Range:</div><div class="bar"><div id="w_range" class="barValue"></div></div></p>
+			<p><div class="attr">Damage:</div><div class="bar"><div id="w_damage" class="barValue"></div></div></p>
+			<p><div class="attr">Fire Rate:</div><div class="bar"><div id="w_rate" class="barValue"></div></div></p>
+			<p class="text" id="w_description"></p>
 			</div>
 		</panel>
-		<tab>Upgrades</tab>
+		<tab onclick="UpgradeClear(document) BuildUpgradeMenu(document)">Upgrades</tab>
 		<panel>
-		<circlemenu id="upgrades" source="armouryBuyList.upgrades" fields="num" formatter="CMArmouryBuyUpgrades" onCancel="Events.pushevent('hide human_buy', event)"/>
+		<div class="circlemenu-circle" id="upgrades"/>
 			<div class="infobox">
-			<h2><datasource_single source="armouryBuyList.upgrades" fields="name" targetid="upgrades" /></h2>
-			<p><div class="attr">Price:</div><div class="bar"><datasource_single source="armouryBuyList.upgrades" fields="price" targetid="upgrades" /></div></p>
-			<p class="text"><datasource_single source="armouryBuyList.upgrades" fields="description" targetid="upgrades" /></p>
+			<h2 id="u_name"></h2>
+			<p><div class="attr">Price:</div><div class="bar"><div id="u_price"></div></div></p>
+			<p class="text" id="u_description"></p>
 			</div>
 		</panel>
 	</tabset>
-	</div>
 	</body>
 </rml>

--- a/ui/human_buy.rml
+++ b/ui/human_buy.rml
@@ -125,6 +125,7 @@
 						'<button class="%s" onclick="WeaponClick(%d)" onmouseover="WeaponHover(document,%d)">%s<img src="/%s"/></button>',
 						weapons[i][5], i, i, AvailabilityIcon(weapons[i][5]), weapons[i][1])
 				end
+				document:GetElementById("weaponKeyboardHints").inner_rml = CirclemenuKeyboardHints(#weapons)
 			end
 			function UpgradeClick(idx)
 				if idx > #upgrades then return end
@@ -159,6 +160,7 @@
 						'<button class="%s" onclick="UpgradeClick(%d)" onmouseover="UpgradeHover(document,%d)">%s<img src="/%s"/></button>',
 						upgrades[i][5], i, i, AvailabilityIcon(upgrades[i][5]), upgrades[i][1])
 				end
+				document:GetElementById("upgradeKeyboardHints").inner_rml = CirclemenuKeyboardHints(#upgrades)
 			end
 			function HumanBuyHandleKey(event, document)
 				local tabset = Element.As.ElementTabSet(document:GetElementById("tabset"))
@@ -173,6 +175,7 @@
 	<tabset class="circlemenu" id="tabset">
 		<tab onclick="WeaponClear(document) BuildWeaponMenu(document)">Weapons</tab>
 		<panel>
+		<div class="circlemenu-circle" id="weaponKeyboardHints"/>
 		<div class="circlemenu-circle" id="weapons"/>
 			<div class="infobox">
 			<h2 id="w_name"></h2>
@@ -185,6 +188,7 @@
 		</panel>
 		<tab onclick="UpgradeClear(document) BuildUpgradeMenu(document)">Upgrades</tab>
 		<panel>
+		<div class="circlemenu-circle" id="upgradeKeyboardHints"/>
 		<div class="circlemenu-circle" id="upgrades"/>
 			<div class="infobox">
 			<h2 id="u_name"></h2>

--- a/ui/human_buy.rml
+++ b/ui/human_buy.rml
@@ -84,6 +84,37 @@
 .circlemenu button.active .sell{
 	display:none;
 }
+
+.tabkey {
+	background-color: #99999999;
+	color: #CCCCCC;
+	font-size: 0.8em;
+	line-height: 0.85em;
+	padding-left: 0.1em;
+	padding-right: 0.1em;
+	border-top-style: solid;
+	border-bottom-style: solid;
+	border-right-style: solid;
+	border-left-style: solid;
+	border-top-width: .1em;
+	border-bottom-width: .1em;
+	border-right-width: .1em;
+	border-left-width: .1em;
+	border-top-color: #CCCCCC;
+	border-bottom-color: #CCCCCC;
+	border-right-color: #CCCCCC;
+	border-left-color: #CCCCCC;
+}
+tab:selected .tabkey {
+	display: none;
+}
+tab {
+	position: relative;
+	top: 0.4em;
+}
+tab:selected {
+	top: 0;
+}
 		</style>
 		<script>
 			function WeaponClick(idx)
@@ -164,8 +195,12 @@
 			end
 			function HumanBuyHandleKey(event, document)
 				local tabset = Element.As.ElementTabSet(document:GetElementById("tabset"))
-				local handler = ({[0]=WeaponClick, [1]=UpgradeClick})[tabset.active_tab]
-				CirclemenuHandleKey(event, document, handler)
+				if event.parameters.key_identifier == rocket.key_identifier.TAB then
+					tabset.active_tab = 1 - tabset.active_tab
+				else
+					local handler = ({[0]=WeaponClick, [1]=UpgradeClick})[tabset.active_tab]
+					CirclemenuHandleKey(event, document, handler)
+				end
 			end
 		</script>
 	</head>
@@ -173,7 +208,10 @@
 	 onshow="WeaponClear(document) UpgradeClear(document) BuildWeaponMenu(document) BuildUpgradeMenu(document)"
 	 onrefreshdata="BuildWeaponMenu(document) BuildUpgradeMenu(document)">
 	<tabset class="circlemenu" id="tabset">
-		<tab onclick="WeaponClear(document) BuildWeaponMenu(document)">Weapons</tab>
+		<tab onclick="WeaponClear(document) BuildWeaponMenu(document)">
+			<p>Weapons</p>
+			<div class="tabkey">TAB</div>
+		</tab>
 		<panel>
 		<div class="circlemenu-circle" id="weaponKeyboardHints"/>
 		<div class="circlemenu-circle" id="weapons"/>
@@ -186,7 +224,10 @@
 			<p class="text" id="w_description"></p>
 			</div>
 		</panel>
-		<tab onclick="UpgradeClear(document) BuildUpgradeMenu(document)">Upgrades</tab>
+		<tab onclick="UpgradeClear(document) BuildUpgradeMenu(document)">
+			<p>Upgrades</p>
+			<div class="tabkey">TAB</div>
+		</tab>
 		<panel>
 		<div class="circlemenu-circle" id="upgradeKeyboardHints"/>
 		<div class="circlemenu-circle" id="upgrades"/>

--- a/ui/ingame_beaconmenu.rml
+++ b/ui/ingame_beaconmenu.rml
@@ -6,7 +6,6 @@
 		<style>
 			body
 			{
-				padding-top:10%;
 				width:100%;
 				height:100%;
 				background:#00000066;
@@ -37,38 +36,55 @@
 				color:#9AFFBD;
 			}
 
-			div.infobox {
-				position: absolute;
-				top: 40%;
-				right: 10%;
-				float: right;
-				width: 45%;
-				height: 50%;
-			}
-
 			.circlemenu button img
 			{
 				color: rgb(230,230,230);
 			}
 		</style>
 		<script src="lua/util.lua" />
+		<script>
+			function BeaconClick(idx, event)
+				Cmd.exec("beacon " .. beacons[idx][2])
+				Events.pushevent("hide ingame_beaconmenu", event)
+			end
+			function BeaconHover(document, idx)
+				ClearBeaconInfo(document)
+				local beacon = beacons[idx]
+				document:GetElementById("beaconName"):AppendChild(document:CreateTextNode(beacon[2]))
+				document:GetElementById("beaconDesc"):AppendChild(document:CreateTextNode(beacon[3]))
+			end
+			function ClearBeaconInfo(document)
+				document:GetElementById("beaconName").inner_rml = ""
+				document:GetElementById("beaconDesc").inner_rml = ""
+			end
+			function BuildBeaconMenu(document)
+				ClearBeaconInfo(document)
+				if beacons == nil then
+					CDataSource.Build("beaconList", "default")
+					beacons = CDataSource.Read("beaconList", "default", "icon,name,desc")
+				end
+				local circlemenu = document:GetElementById("beaconMenu")
+				circlemenu.inner_rml = CirclemenuSkeleton(#beacons)
+				for i=1,#beacons do
+					circlemenu.child_nodes[i].inner_rml = string.format(
+						'<button onclick="BeaconClick(%d, event)" onmouseover="BeaconHover(document,%d)"><img src="/%s"/></button>',
+						i, i, beacons[i][1])
+				end
+			end
+		</script>
 	</head>
-	<body id="ingame_beaconmenu" class="circlemenu" onKeyDown="detectEscape(event, document)" onShow='Events.pushevent("buildDS beaconList default", event)'>
-		<div id="foo">
-			<tabset class="circlemenu">
-				<tab>Beacons</tab>
-				<panel>
-				<circlemenu id="default" source="beaconList.default" fields="num" formatter="CMBeacons" onCancel="Events.pushevent('hide ingame_beaconmenu', event)"/>
+	<body id="ingame_beaconmenu" class="circlemenu" onkeydown="detectEscape(event, document)" onshow="BuildBeaconMenu(document)">
+		<tabset class="circlemenu">
+			<tab>Beacons</tab>
+			<panel>
+				<div class="circlemenu-circle" id="beaconMenu"/>
+				<div style="position: absolute; left: 0; width: 40%;">
 					<div class="infobox">
-						<h2>
-							<datasource_single source="beaconList.default" fields="name" targetid="default"/>
-						</h2>
-						<p class="text" style="text-align: left;">
-							<datasource_single source="beaconList.default" fields="desc" targetid="default"/>
-						</p>
+						<h2 id="beaconName"></h2>
+						<p class="text" style="text-align: left;" id="beaconDesc"></p>
 					</div>
-				</panel>
-			</tabset>
-		</div>
+				</div>
+			</panel>
+		</tabset>
 	</body>
 </rml>

--- a/ui/ingame_beaconmenu.rml
+++ b/ui/ingame_beaconmenu.rml
@@ -44,6 +44,7 @@
 		<script src="lua/util.lua" />
 		<script>
 			function BeaconClick(idx, event)
+				if idx > #beacons then return end
 				Cmd.exec("beacon " .. beacons[idx][2])
 				Events.pushevent("hide ingame_beaconmenu", event)
 			end
@@ -73,7 +74,7 @@
 			end
 		</script>
 	</head>
-	<body id="ingame_beaconmenu" class="circlemenu" onkeydown="detectEscape(event, document)" onshow="BuildBeaconMenu(document)">
+	<body id="ingame_beaconmenu" class="circlemenu" onkeydown="CirclemenuHandleKey(event, document, BeaconClick)" onshow="BuildBeaconMenu(document)">
 		<tabset class="circlemenu">
 			<tab>Beacons</tab>
 			<panel>

--- a/ui/ingame_beaconmenu.rml
+++ b/ui/ingame_beaconmenu.rml
@@ -71,6 +71,7 @@
 						'<button onclick="BeaconClick(%d, event)" onmouseover="BeaconHover(document,%d)"><img src="/%s"/></button>',
 						i, i, beacons[i][1])
 				end
+				document:GetElementById("keyboardHints").inner_rml = CirclemenuKeyboardHints(#beacons)
 			end
 		</script>
 	</head>
@@ -78,6 +79,7 @@
 		<tabset class="circlemenu">
 			<tab>Beacons</tab>
 			<panel>
+				<div class="circlemenu-circle" id="keyboardHints"/>
 				<div class="circlemenu-circle" id="beaconMenu"/>
 				<div style="position: absolute; left: 0; width: 40%;">
 					<div class="infobox">

--- a/ui/lua/util.lua
+++ b/ui/lua/util.lua
@@ -71,6 +71,18 @@ function CirclemenuSkeleton(num_items)
 	return rml
 end
 
+function CirclemenuKeyboardHints(num_items)
+	local rml = ""
+	local radius_em = 6.3
+	for i=1,num_items do
+		local angle = 2 * math.pi / num_items * (i - 1)
+		local x = radius_em * math.sin(angle)
+		local y = radius_em * -math.cos(angle)
+		rml = rml .. string.format('<div style="position: absolute; left: %.1fem; top: %.1fem;"><p class="key">%d</p></div>', x, y, i % 10)
+	end
+	return rml
+end
+
 -- The num_handler callback will be given two arguments: an integer in
 -- [1, 10] indicating which item the user selects, and the key event
 function CirclemenuHandleKey(event, document, num_handler)

--- a/ui/lua/util.lua
+++ b/ui/lua/util.lua
@@ -71,6 +71,22 @@ function CirclemenuSkeleton(num_items)
 	return rml
 end
 
+-- The num_handler callback will be given two arguments: an integer in
+-- [1, 10] indicating which item the user selects, and the key event
+function CirclemenuHandleKey(event, document, num_handler)
+	local key = event.parameters["key_identifier"]
+	local index
+	if key == rocket.key_identifier["0"] then
+		index = 10
+	elseif key >= rocket.key_identifier["1"] and key <= rocket.key_identifier["9"] then
+		index = key - rocket.key_identifier["1"] + 1
+	else
+		detectEscape(event, document)
+		return
+	end
+	num_handler(index, event)
+end
+
 function welcome(event, document)
   if Cvar.get("cg_welcome") ~= "1" and Cvar.get("name") == "UnnamedPlayer" then
     Cvar.set("name", "Player#" .. math.ceil(math.random()*10000000))

--- a/ui/lua/util.lua
+++ b/ui/lua/util.lua
@@ -44,6 +44,33 @@ function detectEscape(event, document)
 	end
 end
 
+function AvailabilityIcon(availability)
+	if availability == "active" then
+		-- Check mark icon. UTF-8 encoding of \uf00c
+		return "<icon>\xEF\x80\x8C</icon>"
+	elseif availability == "locked" then
+		-- Padlock icon. UTF-8 encoding of \uf023
+		return "<icon>\xEF\x80\xA3</icon>"
+	elseif availability == "expensive" then
+		-- $1 bill icon. UTF-8 encoding of \uf0d6
+		return "<icon>\xEF\x83\x96</icon>";
+	else
+		return ""
+	end
+end
+
+function CirclemenuSkeleton(num_items)
+	local rml = '<button class="cancelButton" onClick="document:Hide()">Cancel</button>'
+	local radius_em = 10
+	for i = 0, num_items-1 do
+		local angle = 2 * math.pi / num_items * i
+		local x = radius_em * math.sin(angle)
+		local y = radius_em * -math.cos(angle)
+		rml = rml .. string.format('<div style="position: absolute; left: %.1fem; top: %.1fem;"></div>', x, y)
+	end
+	return rml
+end
+
 function welcome(event, document)
   if Cvar.get("cg_welcome") ~= "1" and Cvar.get("name") == "UnnamedPlayer" then
     Cvar.set("name", "Player#" .. math.ceil(math.random()*10000000))

--- a/ui/shared/circlemenu.rcss
+++ b/ui/shared/circlemenu.rcss
@@ -85,3 +85,15 @@ div.circlemenu-circle {
 	height: 4.2em;
 	margin: auto;
 }
+
+.circlemenu .key {
+	color: #CCCCCC;
+	icon-image: /ui/assets/circlemenu/circle.png;
+	icon-decorator: image;
+	position: absolute;
+	left: -.7em;
+	top: -.7em;
+	width: 1.4em;
+	height: 1.4em;
+	text-align: center;
+}

--- a/ui/shared/circlemenu.rcss
+++ b/ui/shared/circlemenu.rcss
@@ -4,14 +4,7 @@
 	width: 8%;
 	color: #83fff5;
 	white-space: nowrap;
-
-	padding: .4em 1.6em 0em 1.6em;
-	margin: .8em;
-}
-
-.circlemenu panel {
-	width: 50%;
-	height: 50%;
+	text-align: center;
 }
 
 .circlemenu tab:selected {
@@ -21,35 +14,39 @@
 	border-bottom-color: #83fff5;
 }
 
-tabset.circlemenu tabs {
-	z-index: 1;
-	text-align: left;
+tabset.circlemenu panel {
 	position: absolute;
-	margin-top: 2.5em;
-	padding-left: 15%;
+	left: 50%;
+	top: 50%;
 }
 
-circlemenu {
+tabset.circlemenu tabs {
+	position: absolute;
+	top: 50%;
+	margin: -17em auto 0;
+}
+
+div.circlemenu-circle {
 	display: block;
 	width: 100%;
-	margin-left: -17%;
-	margin-top: 1em;
-	position: absolute;
-	height: 130%;
-	radius: 14em;
-	vertical-align: middle;
+	height: 100%;
 	text-align: center;
+	position: absolute;
+	left: 0;
+	top: 0;
 }
 
-.circlemenu button, .circlemenu button:hover {
-	margin-left: -2.6em;
+.circlemenu button {
 	display: block;
+	position: relative;
 	width: 6.7em;
 	height: 6.7em;
-	vertical-align: middle;
+	left: -3.35em;
+	top: -3.35em;
 	text-align: center;
 	icon-decorator: image;
 	icon-image: /ui/assets/circlemenu/circle.png;
+	z-index: 2;
 }
 .circlemenu button:hover, .circlemenu button:active, .circlemenu button:focus{
 	icon-image: /ui/assets/circlemenu/circle-hover.png;
@@ -70,8 +67,11 @@ circlemenu {
 }
 
 .circlemenu button.cancelButton {
+	position:absolute;
 	width: 9em;
 	height: 9em;
+	left: -4.5em;
+	top: -4.5em;
 	line-height: 7.8em;
 }
 

--- a/ui/shared/infobox.rcss
+++ b/ui/shared/infobox.rcss
@@ -1,14 +1,19 @@
 /* infobox (for circlemenus) */
 
+div.infobox {
+	position: absolute;
+	left: 15em;
+	top: -12em;
+	width: 18em;
+}
+
 .infobox p {
 	display: block;
 }
 
 .infobox h2 {
-	position: absolute;
-	top: -2em;
 	margin: auto;
-	margin-left: -1em;
+	margin-bottom: 0.8em;
 	font-size: 2em;
 	display: block;
 	text-align: center;

--- a/ui/shared/infobox.rcss
+++ b/ui/shared/infobox.rcss
@@ -1,4 +1,4 @@
-/* infobx */
+/* infobox (for circlemenus) */
 
 .infobox p {
 	display: block;

--- a/ui/transition_loading.rml
+++ b/ui/transition_loading.rml
@@ -1,7 +1,6 @@
 <rml>
 	<head>
 		<link type="text/rcss" href="/ui/shared/basics.rcss" />
-		<link type="text/rcss" href="/ui/shared/infobox.rcss" />
 		<style>
 
 			body {


### PR DESCRIPTION
Depends on https://github.com/Unvanquished/Unvanquished/pull/1348.

UX improvements to the circle menu:
- Position in the center of the screen, so that the cursor appears in the center (as suggested by @necessarily-equal)
- Add the ability to select items with number keys, for faster usage

![unvanquished-beaconmenu-nums](https://user-images.githubusercontent.com/7809431/111455211-7e530400-86e3-11eb-9050-b653bd8e455b.jpg)

For the moment I have applied the changes only to the beacons circle menu, which can be opened by `/beaconmenu`.

Additionally, the circle menu code is generated in Lua instead of C++. Besides being simpler/cleaner in my opinion, this way is much better for development in a couple ways:
- Changes can be tested by just reloading the UI (e.g. `/vid_restart`), without recompiling
- Changes can be mostly made in this repository, rather than a mixture of both it and `Unvanquished`.