### PR TITLE
presets: enable fastsky with lowest graphics

### DIFF
--- a/presets/graphics/high.cfg
+++ b/presets/graphics/high.cfg
@@ -14,6 +14,8 @@ r_imageMaxDimension 2048
 r_ext_multisample 8
 r_ext_texture_filter_anisotropic 8
 r_texturemode "GL_LINEAR_MIPMAP_LINEAR"
+r_clear 1
+r_fastsky 0
 cg_shadows 1
 cg_playerShadows 1
 cg_buildableShadows 0

--- a/presets/graphics/low.cfg
+++ b/presets/graphics/low.cfg
@@ -14,6 +14,8 @@ r_imageMaxDimension 256
 r_ext_multisample 2
 r_ext_texture_filter_anisotropic 2
 r_texturemode "GL_LINEAR_MIPMAP_NEAREST"
+r_clear 1
+r_fastsky 0
 cg_shadows 1
 cg_playerShadows 0
 cg_buildableShadows 0

--- a/presets/graphics/lowest.cfg
+++ b/presets/graphics/lowest.cfg
@@ -14,6 +14,8 @@ r_imageMaxDimension 64
 r_ext_multisample 0
 r_ext_texture_filter_anisotropic 0
 r_texturemode "GL_LINEAR_MIPMAP_NEAREST"
+r_clear 1
+r_fastsky 1
 cg_shadows 0
 cg_playerShadows 0
 cg_buildableShadows 0

--- a/presets/graphics/medium.cfg
+++ b/presets/graphics/medium.cfg
@@ -14,6 +14,8 @@ r_imageMaxDimension 512
 r_ext_multisample 4
 r_ext_texture_filter_anisotropic 4
 r_texturemode "GL_LINEAR_MIPMAP_LINEAR"
+r_clear 1
+r_fastsky 0
 cg_shadows 1
 cg_playerShadows 1
 cg_buildableShadows 1

--- a/presets/graphics/ultra.cfg
+++ b/presets/graphics/ultra.cfg
@@ -14,6 +14,8 @@ r_imageMaxDimension 4096
 r_ext_multisample 16
 r_ext_texture_filter_anisotropic 16
 r_texturemode "GL_LINEAR_MIPMAP_LINEAR"
+r_clear 1
+r_fastsky 0
 cg_shadows 1
 cg_playerShadows 1
 cg_buildableShadows 1

--- a/ui/options_graphics.rml
+++ b/ui/options_graphics.rml
@@ -34,7 +34,7 @@
 				<h2>Presets</h2>
 				<row>
 					<button onClick='Events.pushevent("exec preset presets/graphics/lowest.cfg", event)'>Lowest</button>
-					<span>No multitexturing, no shadows, no bouncing particles, 64-pixel textures…</span>
+					<span>Low subdivisions, no sky, no shadow, no bouncing particles, 64-pixel textures…</span>
 				</row>
 				<row>
 					<button onClick='Events.pushevent("exec preset presets/graphics/low.cfg", event)'>Low</button>


### PR DESCRIPTION
Also enable GL Clearing with all presets.

Also reword a bit the description of the `lowest` preset, not mentioning there is no multitexturing (`low` does not have it as well).
