### PR TITLE
bots: add aliveTime condition

### DIFF
--- a/bots/camper.bt
+++ b/bots/camper.bt
@@ -30,7 +30,10 @@ selector
 			{
 				action heal
 			}
-			action evolve
+			condition ( aliveTime > 1500 )
+			{
+				action evolve
+			}
 			action roamInRadius( E_A_OVERMIND, 500 )
 		}
 	}

--- a/bots/default.bt
+++ b/bots/default.bt
@@ -68,7 +68,10 @@ selector
 
 	condition team == TEAM_ALIENS
 	{
-		action evolve
+		condition ( aliveTime > 1500 )
+		{
+			action evolve
+		}
 	}
 
 	sequence

--- a/bots/reckless.bt
+++ b/bots/reckless.bt
@@ -14,7 +14,10 @@ selector
 	
 	condition team == TEAM_ALIENS
 	{
-		action evolve
+		condition ( aliveTime > 1500 )
+		{
+			action evolve
+		}
 	}
 	
 	action rush


### PR DESCRIPTION
Make sure bots wait a little (currently `1.5s`) before trying to evolve after spawn, given eggs are usually hidden in small places, the surface where the egg is may not be disconnected as dretch, but may be disconnected as dragoon.

See https://github.com/Unvanquished/Unvanquished/pull/1310