### PR TITLE
use hw:c by default to taunt in wasd presets

### DIFF
--- a/presets/input/wasd.cfg
+++ b/presets/input/wasd.cfg
@@ -58,8 +58,8 @@ bind  hw:e          +deconstruct
 // MISC
 //
 
-bind  hw:[          +taunt
-// bind  hw:]          voiceMenu // not implemented yet
+bind  hw:c          +taunt
+// bind  hw:v          voiceMenu // not implemented yet
 bind  hw:b          beaconMenu
 
 bind  ENTER         modcase SHIFT message_team message_public


### PR DESCRIPTION
0.51 used 'c' key, which have only advantages over the new hw:[ key:

* closer to directional keys (wasd/zqsd depending on layout)
* same key in all qwerty and azerty layouts I'm aware of (not many, but
  still)
* less surprising to people which have played to 0.51 (since old
  defaults)

closes #1405