### PR TITLE
gives (most) alien blobs some volume

### DIFF
--- a/configs/missiles/bounceball.attr.cfg
+++ b/configs/missiles/bounceball.attr.cfg
@@ -7,7 +7,7 @@ splashRadius       75
 splashMeansOfDeath MOD_LEVEL3_BOUNCEBALL
 
 clipmask           MASK_SHOT
-size               0
+size               5
 
 trajectory         TR_GRAVITY
 speed              1000

--- a/configs/missiles/lockblob.attr.cfg
+++ b/configs/missiles/lockblob.attr.cfg
@@ -3,7 +3,7 @@ damage             0
 meansOfDeath       MOD_UNKNOWN
 
 clipmask           MASK_SHOT
-size               0
+size               5
 
 trajectory         TR_LINEAR
 speed              500

--- a/configs/missiles/slowblob.attr.cfg
+++ b/configs/missiles/slowblob.attr.cfg
@@ -3,7 +3,7 @@ damage             4
 meansOfDeath       MOD_SLOWBLOB
 
 clipmask           MASK_SHOT
-size               0
+size               5
 
 trajectory         TR_GRAVITY
 speed              800


### PR DESCRIPTION
After few discussions on IRC today, I got a look at alien's missiles sizes. Most have a size of 0, which the code interprets as something very small. I think this is fine for the Hive, since bees should be small, but for blobs, I think it just makes it harder to use them and that might not be intended.
This commit sets those sizes at 5, which is the usual size: another numbers might be better choices.