### PR TITLE
split default.bt to have one per faction

### DIFF
--- a/bots/default.bt
+++ b/bots/default.bt
@@ -2,102 +2,13 @@ selector
 {
 	behavior unstick
 
-	behavior use_medkit
-
-	sequence
+	condition ( team == TEAM_ALIENS )
 	{
-		condition alertedToEnemy
-		selector
-		{
-			condition haveWeapon( WP_HBUILD ) && ( !buildingIsDamaged || teamateHasWeapon( WP_HBUILD ) )
-			{
-				selector
-				{
-					action equip
-					action flee
-				}
-			}
-
-			decorator timer( 1000 )
-			{
-				selector
-				{
-					sequence
-					{
-						condition alertedToEnemy
-						condition team == TEAM_ALIENS
-						condition ( distanceTo( E_A_OVERMIND ) <= 100 || distanceTo( E_A_BOOSTER ) <= 100 )
-						action fight
-					}
-					sequence
-					{
-						condition ( healScore > 0.5 && percentHealth( E_GOAL ) > 0.3  && random > 0.3 )
-						action heal
-					}
-				}
-			}
-
-			action fight
-		}
+		behavior default_aliens
 	}
 
-	selector
+	condition ( team == TEAM_HUMANS )
 	{
-		sequence
-		{
-			condition team == TEAM_ALIENS
-			condition healScore > 0.25
-			action heal
-		}
-
-		sequence
-		{
-			condition team == TEAM_HUMANS
-			condition !haveUpgrade( UP_MEDKIT )
-			condition healScore > 0.25
-			action heal
-		}
+		behavior default_humans
 	}
-
-	condition team == TEAM_ALIENS
-	{
-		condition ( aliveTime > 1500 )
-		{
-			action evolve
-		}
-	}
-
-	sequence
-	{
-		condition team == TEAM_HUMANS
-		condition !teamateHasWeapon( WP_HBUILD )
-		condition buildingIsDamaged
-		decorator timer( 50000 )
-		{
-			selector
-			{
-				condition !haveWeapon( WP_HBUILD )
-				{
-					action buy( WP_HBUILD )
-				}
-
-				condition haveWeapon( WP_HBUILD )
-				{
-					action repair
-				}
-			}
-		}
-	}
-
-	condition team == TEAM_HUMANS
-	{
-		action equip
-	}
-
-	condition baseRushScore > 0.5
-	{
-		action rush
-	}
-
-	action roam
 }

--- a/bots/default_aliens.bt
+++ b/bots/default_aliens.bt
@@ -1,0 +1,50 @@
+selector
+{
+	sequence
+	{
+		condition alertedToEnemy
+		selector
+		{
+			decorator timer( 1000 )
+			{
+				selector
+				{
+					sequence
+					{
+						condition alertedToEnemy
+						condition ( distanceTo( E_A_OVERMIND ) <= 100 || distanceTo( E_A_BOOSTER ) <= 100 )
+						action fight
+					}
+					sequence
+					{
+						condition ( healScore > 0.5 && percentHealth( E_GOAL ) > 0.3  && random > 0.3 )
+						action heal
+					}
+				}
+			}
+
+			action fight
+		}
+	}
+
+	selector
+	{
+		sequence
+		{
+			condition healScore > 0.25
+			action heal
+		}
+	}
+
+	condition ( aliveTime > 1500 )
+	{
+		action evolve
+	}
+
+	condition baseRushScore > 0.5
+	{
+		action rush
+	}
+
+	action roam
+}

--- a/bots/default_aliens.bt
+++ b/bots/default_aliens.bt
@@ -1,23 +1,19 @@
 selector
 {
-	sequence
+	condition alertedToEnemy
 	{
-		condition alertedToEnemy
 		selector
 		{
 			decorator timer( 1000 )
 			{
 				selector
 				{
-					sequence
+					condition ( distanceTo( E_A_OVERMIND ) <= 100 || distanceTo( E_A_BOOSTER ) <= 100 )
 					{
-						condition alertedToEnemy
-						condition ( distanceTo( E_A_OVERMIND ) <= 100 || distanceTo( E_A_BOOSTER ) <= 100 )
 						action fight
 					}
-					sequence
+					condition ( healScore > 0.5 && percentHealth( E_GOAL ) > 0.3  && random > 0.3 )
 					{
-						condition ( healScore > 0.5 && percentHealth( E_GOAL ) > 0.3  && random > 0.3 )
 						action heal
 					}
 				}
@@ -27,13 +23,9 @@ selector
 		}
 	}
 
-	selector
+	condition healScore > 0.25
 	{
-		sequence
-		{
-			condition healScore > 0.25
-			action heal
-		}
+		action heal
 	}
 
 	condition ( aliveTime > 1500 )

--- a/bots/default_humans.bt
+++ b/bots/default_humans.bt
@@ -1,0 +1,74 @@
+selector
+{
+	behavior use_medkit
+
+	sequence
+	{
+		condition alertedToEnemy
+		selector
+		{
+			condition haveWeapon( WP_HBUILD ) && ( !buildingIsDamaged || teamateHasWeapon( WP_HBUILD ) )
+			{
+				selector
+				{
+					action equip
+					action flee
+				}
+			}
+
+			decorator timer( 1000 )
+			{
+				selector
+				{
+					sequence
+					{
+						condition ( healScore > 0.5 && percentHealth( E_GOAL ) > 0.3  && random > 0.3 )
+						action heal
+					}
+				}
+			}
+
+			action fight
+		}
+	}
+
+	selector
+	{
+		sequence
+		{
+			condition !haveUpgrade( UP_MEDKIT )
+			condition healScore > 0.25
+			action heal
+		}
+	}
+
+	sequence
+	{
+		condition !teamateHasWeapon( WP_HBUILD )
+		condition buildingIsDamaged
+		decorator timer( 50000 )
+		{
+			selector
+			{
+				condition !haveWeapon( WP_HBUILD )
+				{
+					action buy( WP_HBUILD )
+				}
+
+				condition haveWeapon( WP_HBUILD )
+				{
+					action repair
+				}
+			}
+		}
+	}
+
+	action equip
+
+	condition baseRushScore > 0.5
+	{
+		action rush
+	}
+
+	action roam
+}

--- a/bots/default_humans.bt
+++ b/bots/default_humans.bt
@@ -2,9 +2,8 @@ selector
 {
 	behavior use_medkit
 
-	sequence
+	condition ( alertedToEnemy )
 	{
-		condition alertedToEnemy
 		selector
 		{
 			condition haveWeapon( WP_HBUILD ) && ( !buildingIsDamaged || teamateHasWeapon( WP_HBUILD ) )
@@ -18,13 +17,9 @@ selector
 
 			decorator timer( 1000 )
 			{
-				selector
+				condition ( healScore > 0.5 && percentHealth( E_GOAL ) > 0.3  && random > 0.3 )
 				{
-					sequence
-					{
-						condition ( healScore > 0.5 && percentHealth( E_GOAL ) > 0.3  && random > 0.3 )
-						action heal
-					}
+					action heal
 				}
 			}
 
@@ -32,20 +27,13 @@ selector
 		}
 	}
 
-	selector
+	condition ( !haveUpgrade( UP_MEDKIT ) && healScore > 0.25 )
 	{
-		sequence
-		{
-			condition !haveUpgrade( UP_MEDKIT )
-			condition healScore > 0.25
-			action heal
-		}
+		action heal
 	}
 
-	sequence
+	condition ( !teamateHasWeapon( WP_HBUILD ) && buildingIsDamaged )
 	{
-		condition !teamateHasWeapon( WP_HBUILD )
-		condition buildingIsDamaged
 		decorator timer( 50000 )
 		{
 			selector


### PR DESCRIPTION
Splits the BT in 2, one per faction, and then apply some code clean up.
Previous number of lines was 103, next is 118, but much easier to maintain and improve.

Still, this requires some real testing, since experience shown that bugs can happen fast. This has been sent on my servers for that intent.