### PR TITLE
humans roam near medistat if medistat is busy

### DIFF
--- a/bots/default_humans.bt
+++ b/bots/default_humans.bt
@@ -23,7 +23,11 @@ selector
 					sequence
 					{
 						condition ( healScore > 0.5 && percentHealth( E_GOAL ) > 0.3  && random > 0.3 )
-						action heal
+						selector
+						{
+							action heal
+							action roamInRadius( E_H_MEDISTAT, 250 )
+						}
 					}
 				}
 			}
@@ -38,7 +42,11 @@ selector
 		{
 			condition !haveUpgrade( UP_MEDKIT )
 			condition healScore > 0.25
-			action heal
+			selector
+			{
+				action heal
+				action roamInRadius( E_H_MEDISTAT, 250 )
+			}
 		}
 	}
 


### PR DESCRIPTION
Note that this require «action heal» to be able to fail to work.