### PR TITLE
upscale inventory icons

### DIFF
--- a/ui/hud_human.rml
+++ b/ui/hud_human.rml
@@ -229,7 +229,7 @@
 
 			inventory img
 			{
-				width: 1.5em;
+				width: 1.8em;
 				float: left;
 				clear: right;
 			}


### PR DESCRIPTION
Passes the size of humans inventory icons from 1.5em to 1.8em.
I do not know if those are optimal values, but I think this improves the situation. Icons still needs improvements imo, though.

Comparison:

![2022-01-04-151415_1366x758_scrot](https://user-images.githubusercontent.com/1316300/148074214-7ac92a5e-9c8f-45bb-99f4-3037da3b30ac.png)
![2022-01-04-151448_1366x758_scrot](https://user-images.githubusercontent.com/1316300/148074247-f7bc3d56-c72a-49de-b2b5-77d1506c8474.png)