### PR TITLE
reduce unstick times

### DIFF
--- a/bots/unstick.bt
+++ b/bots/unstick.bt
@@ -12,7 +12,7 @@ selector
 	}
 
 
-	condition(stuckTime > 10000)
+	condition(stuckTime > 5000)
 	{
 		selector
 		{
@@ -21,22 +21,22 @@ selector
 				action suicide
 			}
 
-			decorator timer(3000)
+			decorator timer(1500)
 			{
 				decorator return(STATUS_FAILURE)
 				{
 					action jump
 				}
 			}
-			condition(stuckTime > 17500)
+			condition(stuckTime > 9000)
 			{
 				action moveInDir(MOVE_FORWARD)
 			}
-			condition(stuckTime > 15000)
+			condition(stuckTime > 7000)
 			{
 				action moveInDir(MOVE_RIGHT)
 			}
-			condition(stuckTime > 12500)
+			condition(stuckTime > 6000)
 			{
 				action moveInDir(MOVE_BACKWARD)
 			}


### PR DESCRIPTION
This is something I had in previous betterai's BT, that I lost when I wanted to cleanup everything. Interestingly enough, a player noticed very quickly the change of behaviors.
Those values are like the ones I used before, more or less, that is, mostly divide times by 2. Other values could be used I guess, but one must keep in mind that unvanquihed is a fast game, and 10s doing nothing is a serious problem.