### PR TITLE
aliens reset stucktime if healing

### DIFF
--- a/bots/unstick.bt
+++ b/bots/unstick.bt
@@ -11,6 +11,17 @@ selector
 		}
 	}
 
+	decorator return( STATUS_FAILURE )
+	{
+		// protect alien bots that are healing from being considered stuck
+		sequence
+		{
+			condition team == TEAM_ALIENS && percentHealth( E_SELF ) < 1.0
+			condition goalBuildingType == E_A_OVERMIND && distanceTo( E_GOAL ) <= 128 || goalBuildingType == E_A_BOOSTER && distanceTo( E_GOAL ) <= 200
+			action resetStuckTime
+		}
+	}
+
 
 	condition(stuckTime > 10000)
 	{


### PR DESCRIPTION
I noticed recently that big aliens like tyrants or dragoons will tend to suicide or enter suicide dance near overmind or booster, probably because healing lot of damages takes lot of time.

Thus, let's try to reset stuck time if they're hurt and near overmind or booster, since they can currently only use those to heal reliably.