### PR TITLE
UI improved start local

### DIFF
--- a/ui/server_create.rml
+++ b/ui/server_create.rml
@@ -19,7 +19,7 @@
 	</head>
 	<body template="window" id="createserver" onshow='Events.pushevent("buildDS mapList", event)' style="width: 40em; margin: 1em;">
 		<h1><translate>Start local/LAN game</translate></h1>
-		<form onsubmit='Events.pushevent("execForm \"map $map$\"", event)'>
+		<form onsubmit='Events.pushevent("execForm \"map $map$ $layout$\"", event)'>
 			<row>
 				<input type="text" cvar="sv_hostname" class="text" id="hostname"/>
 				<h3><translate>Hostname</translate></h3>
@@ -33,6 +33,11 @@
 			<row>
 				<input type="text" cvar="fs_extrapaks" class="text" id="extrapaks"/>
 				<h3><translate>Extra packages to load</translate></h3>
+			</row>
+
+			<row>
+				<input type="text" class="text" id="layout" name="layout"/>
+				<h3><translate>Map building layout to use</translate></h3>
 			</row>
 
 			<row id="maplist">

--- a/ui/server_create.rml
+++ b/ui/server_create.rml
@@ -38,12 +38,12 @@
 
 			<row>
 				<input type="text" cvar="g_password" class="text" id="password"/>
-				<h3><translate>Password </translate></h3>
+				<h3><translate>Password</translate></h3>
 			</row>
 
 			<row>
 				<input type="checkbox" id="devmode" style="margin-right:1em;"/>
-				<h3><translate>Developper mode (enable cheats)</translate></h3>
+				<h3><translate>Developer mode (enable cheats)</translate></h3>
 			</row>
 
 			<row>

--- a/ui/server_create.rml
+++ b/ui/server_create.rml
@@ -19,24 +19,29 @@
 	</head>
 	<body template="window" id="createserver" onshow='Events.pushevent("buildDS mapList", event)' style="width: 40em; margin: 1em;">
 		<h1><translate>Start local/LAN game</translate></h1>
-		<row>
-			<input type="text" cvar="sv_hostname" class="text" id="hostname"/>
-			<h3><translate>Hostname</translate></h3>
-		</row>
-		<row>
-			<input type="text" cvar="g_password" class="text" id="password"/>
-			<h3><translate>Password</translate></h3>
-		</row>
-
 		<form onsubmit='Events.pushevent("execForm \"map $map$\"", event)'>
+			<row>
+				<input type="text" cvar="sv_hostname" class="text" id="hostname"/>
+				<h3><translate>Hostname</translate></h3>
+			</row>
+
+			<row>
+				<input type="text" cvar="g_password" class="text" id="password"/>
+				<h3><translate>Password </translate></h3>
+			</row>
+
+			<row>
+				<input type="text" cvar="fs_extrapaks" class="text" id="extrapaks"/>
+				<h3><translate>Extra packages to load</translate></h3>
+			</row>
+
 			<row id="maplist">
 				<dataselect source="mapList.default" fields="mapName" valuefield="mapLoadName" name="map" cvar="ui_dialogCvar1"/>
 				<h3><translate>Map</translate></h3>
 			</row>
 
 			<input type="submit"><button><translate>Start</translate></button></input>
+			<levelshot />
 		</form>
-
-		<levelshot />
 	</body>
 </rml>

--- a/ui/server_create.rml
+++ b/ui/server_create.rml
@@ -16,10 +16,21 @@
 				overflow-y: auto;
 			}
 		</style>
+		<script>
+			function MapMode(document)
+				local AsInput = Element.As.ElementFormControlInput
+				if AsInput(document:GetElementById("devmode")).checked
+				then
+					return 'execForm "devmap $map$ $layout$"'
+				end
+				return 'execForm "map $map$ $layout$"'
+			end
+		</script>
+
 	</head>
 	<body template="window" id="createserver" onshow='Events.pushevent("buildDS mapList", event)' style="width: 40em; margin: 1em;">
 		<h1><translate>Start local/LAN game</translate></h1>
-		<form onsubmit='Events.pushevent("execForm \"map $map$ $layout$\"", event)'>
+		<form onsubmit='Events.pushevent(MapMode(document), event)'>
 			<row>
 				<input type="text" cvar="sv_hostname" class="text" id="hostname"/>
 				<h3><translate>Hostname</translate></h3>
@@ -28,6 +39,11 @@
 			<row>
 				<input type="text" cvar="g_password" class="text" id="password"/>
 				<h3><translate>Password </translate></h3>
+			</row>
+
+			<row>
+				<input type="checkbox" id="devmode" style="margin-right:1em;"/>
+				<h3><translate>Developper mode (enable cheats)</translate></h3>
 			</row>
 
 			<row>


### PR DESCRIPTION
This PR aims at improving the "Start Local/LAN Game" GUI, notably by allowing to enable `/devmap`, editing the CVar `fs_extrapaks` and specifying a map layout.
Ideally:

* the list of maps would changed for a radiobox-list
* the available map layouts would be listed
* a placeholder would be specified instead of the levelshot when no map is selected yet, to avoid the annoying auto-resize

Currently, the layout selection code does not work (hence the draft status). The devmap and the extrapaks are fine though, while they very probably could use style improvements, but I'll let CSS experts handle that part I think, my priority is to make it easier for people to contribute to maps.