### PR TITLE
Bot human fight improvements

### DIFF
--- a/bots/default_humans.bt
+++ b/bots/default_humans.bt
@@ -14,6 +14,7 @@ selector
 					action buy( WP_PULSE_RIFLE )
 				}
 			}
+
 			condition haveWeapon( WP_HBUILD ) && ( !buildingIsDamaged || teamateHasWeapon( WP_HBUILD ) )
 			{
 				selector
@@ -31,7 +32,11 @@ selector
 					// the isVisible check is here to prevent "defending" when enemies are detected by radars
 					condition ( ( distanceTo( E_H_REACTOR ) <= 300 || distanceTo( E_H_MEDISTAT ) <= 250 ) && isVisible( E_ENEMY ) )
 					{
-						action fight
+						concurrent
+						{
+							action resetStuckTime
+							action fight
+						}
 					}
 
 					sequence
@@ -61,7 +66,12 @@ selector
 					action activateUpgrade( UP_GRENADE )
 				}
 			}
-			action fight
+
+			concurrent
+			{
+				action resetStuckTime
+				action fight
+			}
 		}
 	}
 

--- a/bots/default_humans.bt
+++ b/bots/default_humans.bt
@@ -71,6 +71,13 @@ selector
 			{
 				action resetStuckTime
 				action fight
+				decorator return( STATUS_SUCCESS )
+				{
+					condition goalType == ET_BUILDABLE && goalTeam == TEAM_ALIENS && inAttackRange( E_GOAL )
+					{
+						action moveInDir( MOVE_BACKWARD )
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This one have 2 effects when bots fight buildings

* avoid staying in melee for no reason (this possibly have undesirable side effects, still have to test behaviors with painsaw notably)
* reset stuck times when they try to kill a building from too far. You can see that to happen when they target something with i.e. chaingun: if let in peace, after a while they'll start the unstuck dance.