### PR TITLE
rework flamer damage

### DIFF
--- a/configs/missiles/flamer.attr.cfg
+++ b/configs/missiles/flamer.attr.cfg
@@ -1,5 +1,5 @@
 // attributes
-damage             2
+damage             5
 meansOfDeath       MOD_FLAMER
 
 splashDamage       10


### PR DESCRIPTION
Increase the direct damage, people said it was too low.

I increased to `5`. Historically it was `10`, I then reduced it to `2`, people says it's not enough. So direct damage is currently half of what stock 0.52 did.

```
<afontain> also the flamer nerf is probably too strong
<freem> flamer is currently useless with the nerf
<freem> damage nerf should likely be removed, only the ignition nerf have a use
```

One of the big problem of the flamer outside of the ability to paint fire on the floor and almost immediate ignite buildables is that it had both high damage and high rate which made it a very powerful mid-range painsaw.

With `10` one would only have to fire one second to kill a tube. The range of the flamer is even larger than the range of a tube so with `5` a naked human can rip out all the tubes of the default plat23 base without being hurt if no alien defends. With `5`, a player carrying a bsuit can do the same while taking damages.

Thanks to the nightly server the previous attempt was tested, in the same way we can merge this and get this delivered to the nightly server.