### PR TITLE
Human bot heal fix

### DIFF
--- a/bots/default_humans.bt
+++ b/bots/default_humans.bt
@@ -69,7 +69,6 @@ selector
 	{
 		sequence
 		{
-			condition !haveUpgrade( UP_MEDKIT )
 			condition healScore > 0.25
 			selector
 			{


### PR DESCRIPTION
At some point, the medkit condition was reinjected in the code (I had it removed for a long while in my mod). This prevents bots bot heal as long as they have the medkit, which means it's possible for a bot with 90% hp to walk on medistation and not stop to heal.
I took the occasion to reduce a big of ugliness.