### PR TITLE
make creep sizes 3x horizontal size

### DIFF
--- a/configs/buildables/acid_tube.attr.cfg
+++ b/configs/buildables/acid_tube.attr.cfg
@@ -26,5 +26,5 @@ splashRadius      100
 meansOfDeath      alienBuildable
 
 // Misc
-creepSize         64
+creepSize         120
 dretchAttackable

--- a/configs/buildables/barricade.attr.cfg
+++ b/configs/buildables/barricade.attr.cfg
@@ -25,4 +25,4 @@ splashRadius      100
 meansOfDeath      alienBuildable
 
 // Misc
-creepSize         96
+creepSize         210

--- a/configs/buildables/barricade.attr.cfg
+++ b/configs/buildables/barricade.attr.cfg
@@ -25,4 +25,4 @@ splashRadius      100
 meansOfDeath      alienBuildable
 
 // Misc
-creepSize         210
+creepSize         280

--- a/configs/buildables/booster.attr.cfg
+++ b/configs/buildables/booster.attr.cfg
@@ -26,5 +26,5 @@ splashRadius      100
 meansOfDeath      alienBuildable
 
 // Misc
-creepSize         64
+creepSize         120
 transparentTest

--- a/configs/buildables/eggpod.attr.cfg
+++ b/configs/buildables/eggpod.attr.cfg
@@ -26,4 +26,4 @@ splashRadius      100
 meansOfDeath      alienBuildable
 
 // Misc
-creepSize         96
+creepSize         90

--- a/configs/buildables/hive.attr.cfg
+++ b/configs/buildables/hive.attr.cfg
@@ -27,5 +27,5 @@ weapon            hive
 meansOfDeath      alienBuildable
 
 // Misc
-creepSize         64
+creepSize         96
 dretchAttackable

--- a/configs/buildables/leech.attr.cfg
+++ b/configs/buildables/leech.attr.cfg
@@ -26,4 +26,4 @@ splashRadius      200
 meansOfDeath      alienBuildable
 
 // Misc
-creepSize         96
+creepSize         120

--- a/configs/buildables/overmind.attr.cfg
+++ b/configs/buildables/overmind.attr.cfg
@@ -26,4 +26,4 @@ splashRadius      300
 meansOfDeath      alienBuildable
 
 // Misc
-creepSize         270
+creepSize         450

--- a/configs/buildables/overmind.attr.cfg
+++ b/configs/buildables/overmind.attr.cfg
@@ -26,4 +26,4 @@ splashRadius      300
 meansOfDeath      alienBuildable
 
 // Misc
-creepSize         128
+creepSize         270

--- a/configs/buildables/spiker.attr.cfg
+++ b/configs/buildables/spiker.attr.cfg
@@ -26,5 +26,5 @@ splashRadius      100
 meansOfDeath      alienBuildable
 
 // Misc
-creepSize         64
+creepSize         120
 dretchAttackable

--- a/configs/buildables/trapper.attr.cfg
+++ b/configs/buildables/trapper.attr.cfg
@@ -27,6 +27,6 @@ weapon            lockblob
 meansOfDeath      alienBuildable
 
 // Misc
-creepSize         48
+creepSize         90
 transparentTest
 dretchAttackable


### PR DESCRIPTION
Fix https://github.com/Unvanquished/gameplay/issues/18

This makes all alien buildables creep size to 3 times the size of one "horizontal" side size.
I have not tested this yet, I'm notably afraid there will be glitches if I do not obey some undocumented rule about PoT images.
I'm going to run a quick local test for that aspect, but doing the PR so that @necessarily-equal 's systems can catch the PR and host an instance for all players willing to see what it would look like.