### PR TITLE
do not flee if rushScore is high enough

### DIFF
--- a/bots/default_aliens.bt
+++ b/bots/default_aliens.bt
@@ -23,6 +23,7 @@ selector
 					sequence
 					{
 						condition ( healScore > 0.5 && percentHealth( E_GOAL ) > 0.3  && random > 0.3 )
+						condition baseRushScore < 0.75
 						action heal
 					}
 				}

--- a/bots/default_humans.bt
+++ b/bots/default_humans.bt
@@ -37,6 +37,7 @@ selector
 					sequence
 					{
 						condition ( healScore > 0.5 && percentHealth( E_GOAL ) > 0.3  && random > 0.3 )
+						condition baseRushScore < 0.75
 						selector
 						{
 							decorator timer( 3000 )


### PR DESCRIPTION
Currently, bots will run away even in the middle of a rush. This is a pretty annoying behavior, as the point of a rush is to deal as much damages as possible.
Since RushScore now returns a value which depend on both the strength of the bot's current configuration and what they could buy in their next life, this should be pretty beneficial, and hopefully will make bots less campy.