### PR TITLE
Restore a sane default font size.

### DIFF
--- a/ui/shared/basics.rcss
+++ b/ui/shared/basics.rcss
@@ -9,6 +9,7 @@ body {
 	font-family: Roboto;
 	color: #999999;
 	cursor: ui/assets/cursor;
+	font-size: 1.5em;
 }
 
 p {


### PR DESCRIPTION
1.5em is large enough to be readable and the default font size chosen by
RmlUI is too small to be readable.