### PR TITLE
translation: do not ship and blacklist .po files for now

### DIFF
--- a/DELETED
+++ b/DELETED
@@ -1,0 +1,9 @@
+unvanquished translation/game/de.po
+unvanquished translation/game/en.po
+unvanquished translation/game/es.po
+unvanquished translation/game/gl.po
+unvanquished translation/game/it.po
+unvanquished translation/game/pl.po
+unvanquished translation/game/ru.po
+unvanquished translation/game/uk.po
+unvanquished translation/game/fr.po


### PR DESCRIPTION
Thanks to the `DELETED` mechanism (https://github.com/DaemonEngine/Daemon/pull/521) that was first thought to blacklist from dependency paks files a parent pak deleted, we can blacklist bad translation without removing them from repositories.

Note: the engine only guarantees blacklisting files in deps, not files in same pak as the `DELETED` file, it was simpler to implement and we can just delete files in source repositories or at build time instead. To-be-merged code to handle `DELETED` files in Urcheon actually ignore files from `DELETED` when building a package.