### PR TITLE
implement a placeholder changelog

### DIFF
--- a/ui/changelog.rml
+++ b/ui/changelog.rml
@@ -1,0 +1,1 @@
+Changelog placeholder

--- a/ui/gameinfo.rml
+++ b/ui/gameinfo.rml
@@ -1,0 +1,1 @@
+Gameinfo placeholder

--- a/ui/menu_ingame.rml
+++ b/ui/menu_ingame.rml
@@ -113,6 +113,7 @@
 						<indent>
 							<blocklink onclick='Events.pushevent("show help_gameplay", event)'><translate>Gameplay guide</translate></blocklink>
 							<blocklink onclick='Events.pushevent("show help_textentry", event)'><translate>Colour codes and symbols</translate></blocklink>
+							<blocklink onclick='Events.pushevent("show welcome", event)'><translate>Changelog</translate></blocklink>
 						</indent>
 
 						<br />

--- a/ui/menu_main.rml
+++ b/ui/menu_main.rml
@@ -47,6 +47,7 @@
 						<indent>
 							<blocklink onclick='Events.pushevent("show help_gameplay", event)'><translate>Gameplay guide</translate></blocklink>
 							<blocklink onclick='Events.pushevent("show help_textentry", event)'><translate>Colour codes and symbols</translate></blocklink>
+							<blocklink onclick='Events.pushevent("show welcome", event)'><translate>Changelog</translate></blocklink>
 						</indent>
 
 						<br />

--- a/ui/rocket.txt
+++ b/ui/rocket.txt
@@ -34,6 +34,7 @@
 	misc
 	{
 		// ######## Custom section.  Add and remove freely ########
+		ui/welcome.rml
 		ui/options_player.rml
 		ui/options_fov.rml
 		ui/options_graphics.rml

--- a/ui/welcome.rml
+++ b/ui/welcome.rml
@@ -1,0 +1,35 @@
+<rml>
+	<head>
+		<link type="text/template" href="/ui/shared/window.rml" />
+		<style>
+		panel {
+			width: 65%;
+			padding: 0.5em;
+		}
+		</style>
+	</head>
+	<body template="window" id="welcome" style="width:45em; margin: 1em;">
+		<h1>Unvanquished</h1>
+		<tabset>
+			<tab>
+				<img class="emoticon" src="/emoticons/official" />
+				<translate> Welcome </translate>
+			</tab>
+			<panel>
+				<translate><h1>Welcome to Unvanquished.</h1></translate>
+				<translate><h2>Server and Game Information</h2></translate>
+				<br />
+				<button onclick='Events.pushevent("hide welcome",event)'> OK </button>
+			</panel>
+			<tab>
+				<img class="emoticon" src="/emoticons/featured" />
+				<translate> Changelog </translate>
+			</tab>
+			<panel>
+				<translate><h1>Unvanquished Changelog</h1></translate>
+				<br />
+				<button onclick='Events.pushevent("hide welcome",event)'> OK </button>
+			</panel>
+		</tabset>
+	</body>
+</rml>

--- a/ui/welcome.rml
+++ b/ui/welcome.rml
@@ -18,6 +18,7 @@
 			<panel>
 				<translate><h1>Welcome to Unvanquished.</h1></translate>
 				<translate><h2>Server and Game Information</h2></translate>
+				<include src="ui/gameinfo.rml"/>
 				<br />
 				<button onclick='Events.pushevent("hide welcome",event)'> OK </button>
 			</panel>
@@ -27,6 +28,7 @@
 			</tab>
 			<panel>
 				<translate><h1>Unvanquished Changelog</h1></translate>
+				<include src="ui/changelog.rml"/>
 				<br />
 				<button onclick='Events.pushevent("hide welcome",event)'> OK </button>
 			</panel>

--- a/ui/welcome.rml
+++ b/ui/welcome.rml
@@ -1,6 +1,8 @@
 <rml>
 	<head>
+		<link type="text/rcss" href="/ui/shared/basics.rcss" />
 		<link type="text/template" href="/ui/shared/window.rml" />
+		<link type="text/rcss" href="menu.rcss" />
 		<style>
 		panel {
 			width: 65%;
@@ -8,8 +10,10 @@
 		}
 		</style>
 	</head>
-	<body template="window" id="welcome" style="width:45em; margin: 1em;">
+	<body template="window" id="welcome" style="width: 60em; height: 80%; margin: 10em;" >
+		<sidebar style="width: 60em; height: 80%; margin: 0em;">
 		<h1>Unvanquished</h1>
+		<window id="changeloginnerbar" class="innersidebar" style="height: 60%">
 		<tabset>
 			<tab>
 				<img class="emoticon" src="/emoticons/official" />
@@ -33,5 +37,7 @@
 				<button onclick='Events.pushevent("hide welcome",event)'> OK </button>
 			</panel>
 		</tabset>
+		</window>
+		</sidebar>
 	</body>
 </rml>


### PR DESCRIPTION
Companion of https://github.com/Unvanquished/Unvanquished/pull/2045

The changelog file is @cu-kai's without the stuff specific to Der Bunker and with additional "Ok" buttons.

Looks like this:

![2022-08-06-161547_1366x768_scrot](https://user-images.githubusercontent.com/1316300/183252816-c2eb804a-1f91-4d00-9ee6-bd351f4e8011.png)
![2022-08-06-161552_1366x768_scrot](https://user-images.githubusercontent.com/1316300/183252818-24940e93-223f-4503-828b-f1869e01647c.png)

There are menu entries to spawn this from both main and in-game menus.

This PR was done on unvanquished's official repo, so that it's possible to everyone to improve this, instead of doing lot of github comments to ask others to do it.