### PR TITLE
add an outline to all text to vastly improve readability

### DIFF
--- a/ui/hud_overlay.rml
+++ b/ui/hud_overlay.rml
@@ -6,6 +6,7 @@
 			width: 100%;
 			height: 100%;
 			font-size: 18dp;
+			font-effect: outline( 2px #111 );
 		}
 		div {
 			position: absolute;

--- a/ui/shared/basics.rcss
+++ b/ui/shared/basics.rcss
@@ -10,6 +10,7 @@ body {
 	color: #999999;
 	cursor: ui/assets/cursor;
 	font-size: 12dp;
+	font-effect: outline( 1px #111 );
 }
 
 p {


### PR DESCRIPTION
Adds 2px outlines to `cp` messages, and 1px outlines to everything else for improved visibility across the game.

# NOTE:
### This is more noticeable at lower resolutions, but should have the desired effect for everyone. For the below screenshots, I am playing at 1800 x 1000.

A reference has been provided at the bottom of this post showing this change on 1024x768.

Examples:
===

### Chat text:
![image](https://user-images.githubusercontent.com/13281185/188615513-a4959754-2754-4995-b60e-d334029910fa.png)

### Map/game information:
![image](https://user-images.githubusercontent.com/13281185/188615553-77c40bb0-d76a-4f80-ad43-2096a78ae84f.png)

### Messagemode and tutorial:
![image](https://user-images.githubusercontent.com/13281185/188615599-c08f2ed2-72fe-49a1-8f34-573daf8d3c08.png)

### "cp" message:
![image](https://user-images.githubusercontent.com/13281185/188615679-823c45fd-16a7-4338-b556-9bb331fdc5c6.png)

### "cp" message with colour:
![image](https://user-images.githubusercontent.com/13281185/188615756-70831476-edc2-43b1-a65e-46d60146a06d.png)

### "cp" message with colour similar to skybox (this is really where on vanilla, the contrast sucks):
![image](https://user-images.githubusercontent.com/13281185/188615877-83270f9f-eff0-4c1c-bd3a-abc8465cb5f5.png)

### 1024 x 768
![image](https://user-images.githubusercontent.com/13281185/188616876-0f5ae7f7-9231-481b-a9bc-28ad179df9fb.png)
