### PR TITLE
Print level info on map loading screen

### DIFF
--- a/ui/shared/basics.rcss
+++ b/ui/shared/basics.rcss
@@ -13,6 +13,10 @@ body {
 	font-effect: outline( 1px #111 );
 }
 
+div {
+	display: block;
+}
+
 p {
 	display: block;
 	margin-bottom: 0.3em;

--- a/ui/transition_loading.rml
+++ b/ui/transition_loading.rml
@@ -86,13 +86,19 @@
 				width: 100%;
 			}
 
-			servername {
-				display: block;
+			.serverlevelname {
 				font-size: 3em;
 			}
 
-			servermotd {
-				display: block;
+			.serverlevelauthors {
+				font-size: 1.5em;
+			}
+
+			.servername {
+				font-size: 3em;
+			}
+
+			.servermotd {
 				font-size: 1.5em;
 			}
 		</style>
@@ -104,8 +110,10 @@
 		</div>
 
 		<infobox>
-			<servername><hostname/></servername>
-			<servermotd><motd/></servermotd>
+			<div class="serverlevelname"><levelname/></div>
+			<div class="serverlevelauthors"><levelauthors/></div>
+			<div class="servername"><hostname/></div>
+			<div class="servermotd"><motd/></div>
 		</infobox>
 
 		<barbox>


### PR DESCRIPTION
The `<levelinfo/>` element can contain the map name or more complex strings built up by the game with other data, like a translatable string `<mapname> by <author>`.

Requires this to have data to print:

-  https://github.com/Unvanquished/Unvanquished/pull/2226