### PR TITLE
Throw grenades instead of just dropping them on the floor

### DIFF
--- a/configs/missiles/firebomb.attr.cfg
+++ b/configs/missiles/firebomb.attr.cfg
@@ -10,8 +10,8 @@ clipmask           MASK_SHOT
 size               3
 
 trajectory         TR_GRAVITY
-speed              400
-lag                0.0 // TODO: Add a fitting lag
+speed              320
+lag                0.8 // portion of the velocity of the player which is added to the projectile speed
 
 doKnockback
 bounceHalf

--- a/configs/missiles/grenade.attr.cfg
+++ b/configs/missiles/grenade.attr.cfg
@@ -10,8 +10,8 @@ clipmask           MASK_SHOT
 size               3
 
 trajectory         TR_GRAVITY
-speed              400
-lag                0.0 // TODO: Add a fitting lag
+speed              320
+lag                0.8 // portion of the velocity of the player which is added to the projectile speed
 
 doKnockback
 bounceHalf


### PR DESCRIPTION
This also lowers the added speed a bit to avoid throwing them unreasonably far