### PR TITLE
camper.bt: roam freely if it does not work near reactor/overmind

### DIFF
--- a/bots/camper.bt
+++ b/bots/camper.bt
@@ -18,11 +18,7 @@ selector
 				action heal
 			}
 
-			fallback
-			{
-				action roamInRadius( E_H_REACTOR, 500 )
-				action roam
-			}
+			action roamInRadius( E_H_REACTOR, 500 )
 		}
 	}
 
@@ -38,11 +34,9 @@ selector
 			{
 				action evolve
 			}
-			fallback
-			{
-				action roamInRadius( E_A_OVERMIND, 500 )
-				action roam
-			}
+			action roamInRadius( E_A_OVERMIND, 500 )
 		}
 	}
+
+	action roam
 }

--- a/bots/camper.bt
+++ b/bots/camper.bt
@@ -17,8 +17,12 @@ selector
 			{
 				action heal
 			}
-			
-			action roamInRadius( E_H_REACTOR, 500 )
+
+			fallback
+			{
+				action roamInRadius( E_H_REACTOR, 500 )
+				action roam
+			}
 		}
 	}
 
@@ -34,7 +38,11 @@ selector
 			{
 				action evolve
 			}
-			action roamInRadius( E_A_OVERMIND, 500 )
+			fallback
+			{
+				action roamInRadius( E_A_OVERMIND, 500 )
+				action roam
+			}
 		}
 	}
 }


### PR DESCRIPTION
Current camper.bt makes bots using it freeze when their main buildable disappears. This makes them roam instead.