### PR TITLE
Fix camper bot fighting

### DIFF
--- a/bots/camper.bt
+++ b/bots/camper.bt
@@ -8,7 +8,6 @@ selector
 		action fight
 	}
 
-	
 	condition team == TEAM_HUMANS
 	{
 		selector

--- a/bots/camper.bt
+++ b/bots/camper.bt
@@ -2,10 +2,12 @@ selector
 {
 	behavior unstick
 	
-	condition alertedToEnemy
+	sequence
 	{
+		condition alertedToEnemy
 		action fight
 	}
+
 	
 	condition team == TEAM_HUMANS
 	{


### PR DESCRIPTION
There is a subtule difference between the two structures. Notably, with this new `sequence` format, the action fight continues if the enemy is no longer visible. The enemy is thought to be "not visible" more often than you think.

Suggested testing protocol:
* add camper human bots
* sit on the armory as a dragoon or anything else. You should be surprisingly safe without this change.