### PR TITLE
presets: set archive when modifying cvar, also drop unimplemented MSAA, fix Unvanquished/Unvanquished#2340

### DIFF
--- a/presets/graphics/high.cfg
+++ b/presets/graphics/high.cfg
@@ -11,7 +11,6 @@ seta r_heatHaze 1
 seta r_bloom 1
 seta r_subdivisions 4
 seta r_imageMaxDimension 2048
-seta r_ext_multisample 8
 seta r_ext_texture_filter_anisotropic 8
 seta r_textureMode "GL_LINEAR_MIPMAP_LINEAR"
 seta r_clear 1

--- a/presets/graphics/high.cfg
+++ b/presets/graphics/high.cfg
@@ -1,24 +1,24 @@
-r_dynamicLight 2
-r_halfLambertLighting 1
-r_rimLighting 1
-r_vertexLighting 0
-r_normalMapping 1
-r_deluxeMapping 1
-r_specularMapping 1
-r_physicalMapping 1
-r_reliefMapping 0
-r_heatHaze 1
-r_bloom 1
-r_subdivisions 4
-r_imageMaxDimension 2048
-r_ext_multisample 8
-r_ext_texture_filter_anisotropic 8
-r_textureMode "GL_LINEAR_MIPMAP_LINEAR"
-r_clear 1
-r_fastsky 0
-cg_shadows 1
-cg_playerShadows 1
-cg_buildableShadows 0
-cg_bounceParticles 1
-cg_motionblur 0.05
+seta r_dynamicLight 2
+seta r_halfLambertLighting 1
+seta r_rimLighting 1
+seta r_vertexLighting 0
+seta r_normalMapping 1
+seta r_deluxeMapping 1
+seta r_specularMapping 1
+seta r_physicalMapping 1
+seta r_reliefMapping 0
+seta r_heatHaze 1
+seta r_bloom 1
+seta r_subdivisions 4
+seta r_imageMaxDimension 2048
+seta r_ext_multisample 8
+seta r_ext_texture_filter_anisotropic 8
+seta r_textureMode "GL_LINEAR_MIPMAP_LINEAR"
+seta r_clear 1
+seta r_fastsky 0
+seta cg_shadows 1
+seta cg_playerShadows 1
+seta cg_buildableShadows 0
+seta cg_bounceParticles 1
+seta cg_motionblur 0.05
 vid_restart

--- a/presets/graphics/low.cfg
+++ b/presets/graphics/low.cfg
@@ -1,24 +1,24 @@
-r_dynamicLight 0
-r_halfLambertLighting 1
-r_rimLighting 1
-r_vertexLighting 0
-r_normalMapping 0
-r_deluxeMapping 0
-r_specularMapping 0
-r_physicalMapping 0
-r_reliefMapping 0
-r_heatHaze 0
-r_bloom 0
-r_subdivisions 12
-r_imageMaxDimension 256
-r_ext_multisample 2
-r_ext_texture_filter_anisotropic 2
-r_textureMode "GL_LINEAR_MIPMAP_NEAREST"
-r_clear 1
-r_fastsky 0
-cg_shadows 1
-cg_playerShadows 0
-cg_buildableShadows 0
-cg_bounceParticles 1
-cg_motionblur 0
+seta r_dynamicLight 0
+seta r_halfLambertLighting 1
+seta r_rimLighting 1
+seta r_vertexLighting 0
+seta r_normalMapping 0
+seta r_deluxeMapping 0
+seta r_specularMapping 0
+seta r_physicalMapping 0
+seta r_reliefMapping 0
+seta r_heatHaze 0
+seta r_bloom 0
+seta r_subdivisions 12
+seta r_imageMaxDimension 256
+seta r_ext_multisample 2
+seta r_ext_texture_filter_anisotropic 2
+seta r_textureMode "GL_LINEAR_MIPMAP_NEAREST"
+seta r_clear 1
+seta r_fastsky 0
+seta cg_shadows 1
+seta cg_playerShadows 0
+seta cg_buildableShadows 0
+seta cg_bounceParticles 1
+seta cg_motionblur 0
 vid_restart

--- a/presets/graphics/low.cfg
+++ b/presets/graphics/low.cfg
@@ -11,7 +11,6 @@ seta r_heatHaze 0
 seta r_bloom 0
 seta r_subdivisions 12
 seta r_imageMaxDimension 256
-seta r_ext_multisample 2
 seta r_ext_texture_filter_anisotropic 2
 seta r_textureMode "GL_LINEAR_MIPMAP_NEAREST"
 seta r_clear 1

--- a/presets/graphics/lowest.cfg
+++ b/presets/graphics/lowest.cfg
@@ -1,24 +1,24 @@
-r_dynamicLight 0
-r_halfLambertLighting 1
-r_rimLighting 0
-r_vertexLighting 0
-r_normalMapping 0
-r_deluxeMapping 0
-r_specularMapping 0
-r_physicalMapping 0
-r_reliefMapping 0
-r_heatHaze 0
-r_bloom 0
-r_subdivisions 20
-r_imageMaxDimension 64
-r_ext_multisample 0
-r_ext_texture_filter_anisotropic 0
-r_textureMode "GL_LINEAR_MIPMAP_NEAREST"
-r_clear 1
-r_fastsky 1
-cg_shadows 0
-cg_playerShadows 0
-cg_buildableShadows 0
-cg_bounceParticles 0
-cg_motionblur 0
+seta r_dynamicLight 0
+seta r_halfLambertLighting 1
+seta r_rimLighting 0
+seta r_vertexLighting 0
+seta r_normalMapping 0
+seta r_deluxeMapping 0
+seta r_specularMapping 0
+seta r_physicalMapping 0
+seta r_reliefMapping 0
+seta r_heatHaze 0
+seta r_bloom 0
+seta r_subdivisions 20
+seta r_imageMaxDimension 64
+seta r_ext_multisample 0
+seta r_ext_texture_filter_anisotropic 0
+seta r_textureMode "GL_LINEAR_MIPMAP_NEAREST"
+seta r_clear 1
+seta r_fastsky 1
+seta cg_shadows 0
+seta cg_playerShadows 0
+seta cg_buildableShadows 0
+seta cg_bounceParticles 0
+seta cg_motionblur 0
 vid_restart

--- a/presets/graphics/lowest.cfg
+++ b/presets/graphics/lowest.cfg
@@ -11,7 +11,6 @@ seta r_heatHaze 0
 seta r_bloom 0
 seta r_subdivisions 20
 seta r_imageMaxDimension 64
-seta r_ext_multisample 0
 seta r_ext_texture_filter_anisotropic 0
 seta r_textureMode "GL_LINEAR_MIPMAP_NEAREST"
 seta r_clear 1

--- a/presets/graphics/medium.cfg
+++ b/presets/graphics/medium.cfg
@@ -1,24 +1,24 @@
-r_dynamicLight 0
-r_halfLambertLighting 1
-r_rimLighting 1
-r_vertexLighting 0
-r_normalMapping 1
-r_deluxeMapping 1
-r_specularMapping 1
-r_physicalMapping 1
-r_reliefMapping 0
-r_heatHaze 0
-r_bloom 1
-r_subdivisions 8
-r_imageMaxDimension 512
-r_ext_multisample 4
-r_ext_texture_filter_anisotropic 4
-r_textureMode "GL_LINEAR_MIPMAP_LINEAR"
-r_clear 1
-r_fastsky 0
-cg_shadows 1
-cg_playerShadows 1
-cg_buildableShadows 1
-cg_bounceParticles 1
-cg_motionblur 0
+seta r_dynamicLight 0
+seta r_halfLambertLighting 1
+seta r_rimLighting 1
+seta r_vertexLighting 0
+seta r_normalMapping 1
+seta r_deluxeMapping 1
+seta r_specularMapping 1
+seta r_physicalMapping 1
+seta r_reliefMapping 0
+seta r_heatHaze 0
+seta r_bloom 1
+seta r_subdivisions 8
+seta r_imageMaxDimension 512
+seta r_ext_multisample 4
+seta r_ext_texture_filter_anisotropic 4
+seta r_textureMode "GL_LINEAR_MIPMAP_LINEAR"
+seta r_clear 1
+seta r_fastsky 0
+seta cg_shadows 1
+seta cg_playerShadows 1
+seta cg_buildableShadows 1
+seta cg_bounceParticles 1
+seta cg_motionblur 0
 vid_restart

--- a/presets/graphics/medium.cfg
+++ b/presets/graphics/medium.cfg
@@ -11,7 +11,6 @@ seta r_heatHaze 0
 seta r_bloom 1
 seta r_subdivisions 8
 seta r_imageMaxDimension 512
-seta r_ext_multisample 4
 seta r_ext_texture_filter_anisotropic 4
 seta r_textureMode "GL_LINEAR_MIPMAP_LINEAR"
 seta r_clear 1

--- a/presets/graphics/ultra.cfg
+++ b/presets/graphics/ultra.cfg
@@ -11,7 +11,6 @@ seta r_heatHaze 1
 seta r_bloom 1
 seta r_subdivisions 1
 seta r_imageMaxDimension 4096
-seta r_ext_multisample 16
 seta r_ext_texture_filter_anisotropic 16
 seta r_textureMode "GL_LINEAR_MIPMAP_LINEAR"
 seta r_clear 1

--- a/presets/graphics/ultra.cfg
+++ b/presets/graphics/ultra.cfg
@@ -1,24 +1,24 @@
-r_dynamicLight 2
-r_halfLambertLighting 1
-r_rimLighting 1
-r_vertexLighting 0
-r_normalMapping 1
-r_deluxeMapping 1
-r_specularMapping 1
-r_physicalMapping 1
-r_reliefMapping 1
-r_heatHaze 1
-r_bloom 1
-r_subdivisions 1
-r_imageMaxDimension 4096
-r_ext_multisample 16
-r_ext_texture_filter_anisotropic 16
-r_textureMode "GL_LINEAR_MIPMAP_LINEAR"
-r_clear 1
-r_fastsky 0
-cg_shadows 1
-cg_playerShadows 1
-cg_buildableShadows 1
-cg_bounceParticles 1
-cg_motionblur 0.05
+seta r_dynamicLight 2
+seta r_halfLambertLighting 1
+seta r_rimLighting 1
+seta r_vertexLighting 0
+seta r_normalMapping 1
+seta r_deluxeMapping 1
+seta r_specularMapping 1
+seta r_physicalMapping 1
+seta r_reliefMapping 1
+seta r_heatHaze 1
+seta r_bloom 1
+seta r_subdivisions 1
+seta r_imageMaxDimension 4096
+seta r_ext_multisample 16
+seta r_ext_texture_filter_anisotropic 16
+seta r_textureMode "GL_LINEAR_MIPMAP_LINEAR"
+seta r_clear 1
+seta r_fastsky 0
+seta cg_shadows 1
+seta cg_playerShadows 1
+seta cg_buildableShadows 1
+seta cg_bounceParticles 1
+seta cg_motionblur 0.05
 vid_restart

--- a/ui/options_graphics.rml
+++ b/ui/options_graphics.rml
@@ -77,21 +77,8 @@
 				</row>
 
 				<row>
-					<select cvar="r_ext_multisample">
-						<option value="0"><translate>None</translate></option>
-						<option value="2">2×</option>
-						<option value="4">4×</option>
-						<option value="8">8×</option>
-						<option value="16">16×</option>
-					</select>
-					<h3><translate>Multisampling level (MSAA)</translate></h3>
-					<p><translate>Anti-aliasing smoothes out “jaggy edges“ but is very costly to your frame-rate.</translate></p>
-				</row>
-
-				<row>
 					<input cvar="r_FXAA" type="checkbox" />
 					<h3><translate>Fast approximate anti-aliasing (FXAA)</translate></h3>
-					<p><translate>Faster than full MSAA, but not as sharp.</translate></p>
 				</row>
 
 				<buttonbar>


### PR DESCRIPTION
Set archive when modifying cvar

- fix Unvanquished/Unvanquished#2340

Also reset `r_ext_multisample` which isn't implemented yet, since multisampling isn't implemented yet it means the values were never tested and then, if we set or keep a value set to this cvar, people may have the bad surprise of a potential performance hit the day they upgrade the engine to a version that implements the feature.