### PR TITLE
ui: rework the map loading screen

### DIFF
--- a/ui/transition_loading.rml
+++ b/ui/transition_loading.rml
@@ -28,7 +28,7 @@
 			barbox {
 				display: block;
 				width: 100%;
-				height: 2em;
+				height: 2.4em;
 
 				position: absolute;
 				left: 0em;
@@ -43,7 +43,7 @@
 			}
 
 			progress {
-				image-color: #999999cc;
+				image-color: #1ab0b5;
 			}
 
 			statusbox {
@@ -51,7 +51,7 @@
 
 				position: absolute;
 				left: 1em;
-				bottom: 0em;
+				bottom: .2em;
 
 				text-align: left;
 			}
@@ -62,7 +62,7 @@
 
 				position: absolute;
 				right: 1em;
-				bottom: 0em;
+				bottom: .2em;
 
 				text-align: right;
 			}
@@ -80,10 +80,14 @@
 			infobox {
 				display: block;
 				position: absolute;
-				left: 0em;
-				bottom: 10em;
-				text-align: center;
+				bottom: 6em;
 				width: 100%;
+				padding: .7em 1em 1em 1em;
+				background-color: #00000080;
+				border-color: white;
+				border-width: .05em 0em .05em 0em;
+				color: white;
+				text-align: center;
 			}
 
 			.serverlevelname {


### PR DESCRIPTION
This makes the information (map name, author…) more readable whatever the level shot is. I also set the loading bar to the Unvanquished cyan color, also make sure the progress bar text has a bit of bottom margin.

Some graphics designer may want to do something better, but at least this improves readability without being so bad.

Before:

[![map loading screen](https://dl.illwieckz.net/b/unvanquished/wip/map-loading-screen/20230116-170923-000.unvanquished.jpg)](https://dl.illwieckz.net/b/unvanquished/wip/map-loading-screen/20230116-170923-000.unvanquished.jpg)

After:

[![map loading screen](https://dl.illwieckz.net/b/unvanquished/wip/map-loading-screen/20230116-170958-000.unvanquished.jpg)](https://dl.illwieckz.net/b/unvanquished/wip/map-loading-screen/20230116-170958-000.unvanquished.jpg)

Before:

[![map loading screen](https://dl.illwieckz.net/b/unvanquished/wip/map-loading-screen/20230116-170940-000.unvanquished.jpg)](https://dl.illwieckz.net/b/unvanquished/wip/map-loading-screen/20230116-170940-000.unvanquished.jpg)

After:

[![map loading screen](https://dl.illwieckz.net/b/unvanquished/wip/map-loading-screen/20230116-171009-000.unvanquished.jpg)](https://dl.illwieckz.net/b/unvanquished/wip/map-loading-screen/20230116-171009-000.unvanquished.jpg)
