### PR TITLE
ui: clip on browser datagridcell overflow

### DIFF
--- a/ui/server_browser.rml
+++ b/ui/server_browser.rml
@@ -24,6 +24,10 @@
 				display: block;
 			}
 
+			datagridcell {
+				overflow: hidden;
+			}
+
 			button {
 				width: 10em;
 			}


### PR DESCRIPTION
Before (see the ”Der Bunker” entry):

[![browser datagridcell clip](https://dl.illwieckz.net/b/unvanquished/bugs/browser-datagridcell-clip/unvanquished_2023-01-16_232534_000.png)](https://dl.illwieckz.net/b/unvanquished/bugs/browser-datagridcell-clip/unvanquished_2023-01-16_232534_000.png)

After:

[![browser datagridcell clip](https://dl.illwieckz.net/b/unvanquished/bugs/browser-datagridcell-clip/unvanquished_2023-01-16_233516_000.png)](https://dl.illwieckz.net/b/unvanquished/bugs/browser-datagridcell-clip/unvanquished_2023-01-16_233516_000.png)