### PR TITLE
add option to enable/disable light styles in presets and options

### DIFF
--- a/presets/graphics/high.cfg
+++ b/presets/graphics/high.cfg
@@ -1,3 +1,4 @@
+seta r_lightStyles 1
 seta r_dynamicLight 2
 seta r_halfLambertLighting 1
 seta r_rimLighting 1

--- a/presets/graphics/low.cfg
+++ b/presets/graphics/low.cfg
@@ -1,3 +1,4 @@
+seta r_lightStyles 1
 seta r_dynamicLight 0
 seta r_halfLambertLighting 1
 seta r_rimLighting 1

--- a/presets/graphics/lowest.cfg
+++ b/presets/graphics/lowest.cfg
@@ -1,3 +1,4 @@
+seta r_lightStyles 0
 seta r_dynamicLight 0
 seta r_halfLambertLighting 1
 seta r_rimLighting 0

--- a/presets/graphics/medium.cfg
+++ b/presets/graphics/medium.cfg
@@ -1,3 +1,4 @@
+seta r_lightStyles 1
 seta r_dynamicLight 0
 seta r_halfLambertLighting 1
 seta r_rimLighting 1

--- a/presets/graphics/ultra.cfg
+++ b/presets/graphics/ultra.cfg
@@ -1,3 +1,4 @@
+seta r_lightStyles 1
 seta r_dynamicLight 2
 seta r_halfLambertLighting 1
 seta r_rimLighting 1

--- a/ui/options_graphics.rml
+++ b/ui/options_graphics.rml
@@ -97,6 +97,11 @@
 					<h3><translate>Lighting system</translate></h3>
 				</row>
 				<row>
+					<h3><translate>Light styles</translate></h3>
+					<input cvar="r_lightStyles" type="checkbox" checked-value="1" />
+					<p><translate>Precomputed dynamic lights emitted by static map objects.</translate></p>
+				</row>
+				<row>
 					<h3><translate>Dynamic lights</translate></h3>
 					<input cvar="r_dynamicLight" type="checkbox" checked-value="2" />
 					<p><translate>Lighting made by weapons and buildings.</translate></p>

--- a/ui/options_graphics.rml
+++ b/ui/options_graphics.rml
@@ -104,7 +104,7 @@
 				<row>
 					<h3><translate>Dynamic lights</translate></h3>
 					<input cvar="r_dynamicLight" type="checkbox" checked-value="2" />
-					<p><translate>Lighting made by weapons and buildings.</translate></p>
+					<p><translate>Realtime dynamic lights emitted by moving objects like weapons and buildings.</translate></p>
 				</row>
 				<row>
 					<h3><translate>Rim lighting</translate></h3>


### PR DESCRIPTION
`r_lightStyles` is a recent cvar added in https://github.com/DaemonEngine/Daemon/pull/751

Light Styles are precomputed dynamic lights for static map objects: the map compiler bake multiple versions of the same lightmap with different parameters (for example: light on, light off) and the renderer blends them in game to create some effects. It's much cheaper than realtime dynamic lights and not that heavy, Tremulous maps already used this trick a lot.

- Add option to enable disable light styles in graphics option in game,
- Set values in graphics preset, since it's considered “not that heavy”, only the “lowest” profile disables this for now,
- Also reword the dynamic light option description while I was there.