### PR TITLE
no longer use "action heal" in BT

### DIFF
--- a/bots/default_aliens.bt
+++ b/bots/default_aliens.bt
@@ -24,14 +24,7 @@ selector
 					{
 						condition ( healScore > 0.5 && percentHealth( E_GOAL ) > 0.3  && random > 0.3 )
 						condition baseRushScore < 0.75
-						selector
-						{
-							action changeGoal( E_A_BOOSTER )
-							action changeGoal( E_A_OVERMIND )
-							action changeGoal( E_A_SPAWN )
-						}
-						action resetStuckTime
-						action moveToGoal
+						behavior heal
 					}
 				}
 			}
@@ -42,23 +35,7 @@ selector
 
 	condition ( healScore > 0.25 )
 	{
-		sequence
-		{
-			sequence
-			{
-				selector
-				{
-					action changeGoal( E_A_BOOSTER )
-					action changeGoal( E_A_OVERMIND )
-					action changeGoal( E_A_SPAWN )
-				}
-				action moveToGoal
-				condition distanceTo( E_GOAL ) < 5
-				{
-					action resetStuckTime
-				}
-			}
-		}
+		behavior heal
 	}
 
 	condition baseRushScore > 0.5

--- a/bots/default_aliens.bt
+++ b/bots/default_aliens.bt
@@ -40,7 +40,7 @@ selector
 
 	condition baseRushScore > 0.5
 	{
-		action rush
+		behavior rush
 	}
 
 	action roam

--- a/bots/default_aliens.bt
+++ b/bots/default_aliens.bt
@@ -24,7 +24,14 @@ selector
 					{
 						condition ( healScore > 0.5 && percentHealth( E_GOAL ) > 0.3  && random > 0.3 )
 						condition baseRushScore < 0.75
-						action heal
+						selector
+						{
+							action changeGoal( E_A_BOOSTER )
+							action changeGoal( E_A_OVERMIND )
+							action changeGoal( E_A_SPAWN )
+						}
+						action resetStuckTime
+						action moveToGoal
 					}
 				}
 			}
@@ -33,12 +40,24 @@ selector
 		}
 	}
 
-	selector
+	condition ( healScore > 0.25 )
 	{
 		sequence
 		{
-			condition healScore > 0.25
-			action heal
+			sequence
+			{
+				selector
+				{
+					action changeGoal( E_A_BOOSTER )
+					action changeGoal( E_A_OVERMIND )
+					action changeGoal( E_A_SPAWN )
+				}
+				action moveToGoal
+				condition distanceTo( E_GOAL ) < 5
+				{
+					action resetStuckTime
+				}
+			}
 		}
 	}
 

--- a/bots/default_humans.bt
+++ b/bots/default_humans.bt
@@ -36,14 +36,9 @@ selector
 
 					decorator timer( 3000 )
 					{
-						sequence
+						condition healScore > 0.5 && percentHealth( E_GOAL ) > 0.3 && baseRushScore < 0.75 && random > 0.3
 						{
-							condition ( healScore > 0.5 && percentHealth( E_GOAL ) > 0.3 && random > 0.3 )
-							condition ( baseRushScore < 0.75 )
-							condition ( distanceTo( E_GOAL ) > 5 )
-							action changeGoal( E_H_MEDISTAT )
-							action resetStuckTime
-							action moveToGoal
+							behavior heal
 						}
 					}
 				}
@@ -71,12 +66,7 @@ selector
 		{
 			decorator timer( 3000 )
 			{
-				sequence
-				{
-					action changeGoal( E_H_MEDISTAT )
-					action resetStuckTime
-					action moveToGoal
-				}
+				behavior heal
 			}
 			action roamInRadius( E_H_MEDISTAT, 250 )
 		}

--- a/bots/default_humans.bt
+++ b/bots/default_humans.bt
@@ -34,17 +34,16 @@ selector
 						action fight
 					}
 
-					sequence
+					decorator timer( 3000 )
 					{
-						condition ( healScore > 0.5 && percentHealth( E_GOAL ) > 0.3  && random > 0.3 )
-						condition baseRushScore < 0.75
-						selector
+						sequence
 						{
-							decorator timer( 3000 )
-							{
-								action heal
-							}
-							action roamInRadius( E_H_MEDISTAT, 250 )
+							condition ( healScore > 0.5 && percentHealth( E_GOAL ) > 0.3 && random > 0.3 )
+							condition ( baseRushScore < 0.75 )
+							condition ( distanceTo( E_GOAL ) > 5 )
+							action changeGoal( E_H_MEDISTAT )
+							action resetStuckTime
+							action moveToGoal
 						}
 					}
 				}
@@ -66,19 +65,20 @@ selector
 		}
 	}
 
-	selector
+	condition ( healScore > 0.25 )
 	{
-		sequence
+		selector
 		{
-			condition healScore > 0.25
-			selector
+			decorator timer( 3000 )
 			{
-				decorator timer( 3000 )
+				sequence
 				{
-					action heal
+					action changeGoal( E_H_MEDISTAT )
+					action resetStuckTime
+					action moveToGoal
 				}
-				action roamInRadius( E_H_MEDISTAT, 250 )
 			}
+			action roamInRadius( E_H_MEDISTAT, 250 )
 		}
 	}
 

--- a/bots/default_humans.bt
+++ b/bots/default_humans.bt
@@ -104,7 +104,7 @@ selector
 
 	condition baseRushScore > 0.5
 	{
-		action rush
+		behavior rush
 	}
 
 	action roam

--- a/bots/heal.bt
+++ b/bots/heal.bt
@@ -1,0 +1,29 @@
+sequence
+{
+	selector
+	{
+		condition ( team == TEAM_ALIENS )
+		{
+			selector
+			{
+				action changeGoal( E_A_BOOSTER )
+				action changeGoal( E_A_OVERMIND )
+				action changeGoal( E_A_SPAWN )
+			}
+		}
+
+		condition ( team == TEAM_HUMANS )
+		{
+			action changeGoal( E_H_MEDISTAT )
+		}
+	}
+
+	selector
+	{
+		condition ( distanceTo( E_GOAL ) < 5 )
+		{
+			action resetStuckTime
+		}
+		action moveToGoal
+	}
+}

--- a/bots/rush.bt
+++ b/bots/rush.bt
@@ -1,0 +1,28 @@
+sequence
+{
+	selector
+	{
+		condition ( team == TEAM_ALIENS )
+		{
+			selector
+			{
+				action changeGoal( E_H_SPAWN )
+				action changeGoal( E_H_ARMOURY )
+				action changeGoal( E_H_MEDISTAT )
+				action changeGoal( E_H_REACTOR )
+			}
+		}
+
+		condition ( team == TEAM_HUMANS )
+		{
+			selector
+			{
+				action changeGoal( E_A_BOOSTER )
+				action changeGoal( E_A_SPAWN )
+				action changeGoal( E_A_OVERMIND )
+			}
+		}
+	}
+
+	action moveToGoal
+}


### PR DESCRIPTION
This PR simply removes all calls to `action heal` as the action itself is not needed: it's really just a matter of changing goal and going there.