### PR TITLE
add defend.bt, follow.bt, stay-here.bt

### DIFF
--- a/bots/defend.bt
+++ b/bots/defend.bt
@@ -1,0 +1,187 @@
+selector
+{
+	behavior unstick
+
+	condition ( team == TEAM_ALIENS )
+	{
+		selector
+		{
+			condition ( aliveTime > 1500 && healScore < 0.5 )
+			{
+				action evolve
+			}
+
+			sequence
+			{
+				condition alertedToEnemy
+				selector
+				{
+					decorator timer( 1000 )
+					{
+						selector
+						{
+							sequence
+							{
+								condition alertedToEnemy
+								condition ( distanceTo( E_A_OVERMIND ) <= 100 || distanceTo( E_A_BOOSTER ) <= 100 )
+								action fight
+							}
+							sequence
+							{
+								condition ( healScore > 0.5 && percentHealth( E_GOAL ) > 0.3  && random > 0.3 )
+								condition baseRushScore < 0.75
+								action heal
+							}
+						}
+					}
+
+					action fight
+				}
+			}
+
+			selector
+			{
+				sequence
+				{
+					condition healScore > 0.25
+					action heal
+				}
+			}
+
+			fallback
+			{
+				action roamInRadius( E_A_OVERMIND, 500 )
+				action roamInRadius( E_A_SPAWN, 500 )
+				action roamInRadius( E_A_BOOSTER, 500 )
+				action roam
+			}
+		}
+	}
+
+	condition ( team == TEAM_HUMANS )
+	{
+		selector
+		{
+			behavior use_medkit
+
+			sequence
+			{
+				condition alertedToEnemy
+				selector
+				{
+					decorator timer ( 1000 )
+					{
+						condition haveWeapon( WP_LUCIFER_CANNON ) && ( distanceTo( E_H_REACTOR ) <= 400 || distanceTo( E_H_ARMOURY ) <= 400 )
+						{
+							action buy( WP_PULSE_RIFLE )
+						}
+					}
+					condition haveWeapon( WP_HBUILD ) && ( !buildingIsDamaged || teamateHasWeapon( WP_HBUILD ) )
+					{
+						selector
+						{
+							action equip
+							action flee
+						}
+					}
+
+					decorator timer( 1000 )
+					{
+						selector
+						{
+							// defending reactor, or try to avoid being killed while healing (hence the different values)
+							// the isVisible check is here to prevent "defending" when enemies are detected by radars
+							condition ( ( distanceTo( E_H_REACTOR ) <= 300 || distanceTo( E_H_MEDISTAT ) <= 250 ) && isVisible( E_ENEMY ) )
+							{
+								action fight
+							}
+
+							sequence
+							{
+								condition ( healScore > 0.5 && percentHealth( E_GOAL ) > 0.3  && random > 0.3 )
+								condition baseRushScore < 0.75
+								selector
+								{
+									decorator timer( 3000 )
+									{
+										action heal
+									}
+									action roamInRadius( E_H_MEDISTAT, 250 )
+								}
+							}
+						}
+					}
+
+					sequence
+					{
+						//if goal is a close enough enemy building or if we're gonna die
+						condition ( percentHealth( E_SELF ) < 0.3 || ( distanceTo( E_GOAL ) < 400 && goalType == ET_BUILDABLE ) )
+						condition ( distanceTo( E_FRIENDLYBUILDING ) > 400 )
+						selector
+						{
+							// no need to check the upgrade is in inventory, since action would fail
+							action activateUpgrade( UP_FIREBOMB )
+							action activateUpgrade( UP_GRENADE )
+						}
+					}
+					action fight
+				}
+			}
+
+			selector
+			{
+				sequence
+				{
+					condition healScore > 0.25
+					selector
+					{
+						decorator timer( 3000 )
+						{
+							action heal
+						}
+						action roamInRadius( E_H_MEDISTAT, 250 )
+					}
+				}
+			}
+
+			sequence
+			{
+				condition !teamateHasWeapon( WP_HBUILD )
+				condition buildingIsDamaged
+				decorator timer( 50000 )
+				{
+					selector
+					{
+						condition !haveWeapon( WP_HBUILD )
+						{
+							sequence
+							{
+								decorator return( STATUS_SUCCESS )
+								{
+									action equip
+								}
+								action buy( WP_HBUILD )
+							}
+						}
+
+						condition haveWeapon( WP_HBUILD )
+						{
+							action repair
+						}
+					}
+				}
+			}
+
+			action equip
+
+			fallback
+			{
+				action roamInRadius( E_H_REACTOR, 500 )
+				action roamInRadius( E_H_SPAWN, 500 )
+				action roamInRadius( E_H_ARMOURY, 500 )
+				action roamInRadius( E_H_MEDISTAT, 500 )
+				action roam
+			}
+		}
+	}
+}

--- a/bots/follow.bt
+++ b/bots/follow.bt
@@ -1,0 +1,137 @@
+selector
+{
+	behavior unstick
+
+	condition team == TEAM_HUMANS
+	{
+		selector
+		{
+			behavior use_medkit
+
+			sequence
+			{
+				condition alertedToEnemy
+				selector
+				{
+					decorator timer( 1000 )
+					{
+						selector
+						{
+							// defending reactor, or try to avoid being killed while healing (hence the different values)
+							// the isVisible check is here to prevent "defending" when enemies are detected by radars
+							condition ( ( distanceTo( E_H_REACTOR ) <= 300 || distanceTo( E_H_MEDISTAT ) <= 250 ) && isVisible( E_ENEMY ) )
+							{
+								action fight
+							}
+
+							sequence
+							{
+								condition ( healScore > 0.5 && percentHealth( E_GOAL ) > 0.3  && random > 0.3 )
+								condition baseRushScore < 0.75
+								selector
+								{
+									decorator timer( 3000 )
+									{
+										action heal
+									}
+									action roamInRadius( E_H_MEDISTAT, 250 )
+								}
+							}
+						}
+					}
+
+					sequence
+					{
+						//if goal is a close enough enemy building or if we're gonna die
+						condition ( percentHealth( E_SELF ) < 0.3 || ( distanceTo( E_GOAL ) < 400 && goalType == ET_BUILDABLE ) )
+						condition ( distanceTo( E_FRIENDLYBUILDING ) > 400 )
+						selector
+						{
+							// no need to check the upgrade is in inventory, since action would fail
+							action activateUpgrade( UP_FIREBOMB )
+							action activateUpgrade( UP_GRENADE )
+						}
+					}
+					action fight
+				}
+			}
+
+			selector
+			{
+				sequence
+				{
+					condition healScore > 0.25
+					selector
+					{
+						decorator timer( 3000 )
+						{
+							action heal
+						}
+						action roamInRadius( E_H_MEDISTAT, 250 )
+					}
+				}
+			}
+
+			sequence
+			{
+				condition ( distanceTo( E_H_ARMOURY ) < 500 )
+				action equip
+			}
+
+			action follow( 250 )
+			action roam
+		}
+
+	}
+
+	condition team == TEAM_ALIENS
+	{
+		selector
+		{
+			condition ( aliveTime > 1500 && healScore < 0.5 )
+			{
+				action evolve
+			}
+
+			sequence
+			{
+				condition alertedToEnemy
+				selector
+				{
+					decorator timer( 1000 )
+					{
+						selector
+						{
+							sequence
+							{
+								condition alertedToEnemy
+								condition ( distanceTo( E_A_OVERMIND ) <= 100 || distanceTo( E_A_BOOSTER ) <= 100 )
+								action fight
+							}
+							sequence
+							{
+								condition ( healScore > 0.5 && percentHealth( E_GOAL ) > 0.3  && random > 0.3 )
+								condition baseRushScore < 0.75
+								action heal
+							}
+						}
+					}
+
+					action fight
+				}
+			}
+
+			selector
+			{
+				sequence
+				{
+					condition healScore > 0.25
+					action heal
+				}
+			}
+
+			action follow( 250 )
+			action roam
+		}
+	}
+}

--- a/bots/stay-here.bt
+++ b/bots/stay-here.bt
@@ -1,0 +1,137 @@
+selector
+{
+	behavior unstick
+
+	condition team == TEAM_HUMANS
+	{
+		selector
+		{
+			behavior use_medkit
+
+			sequence
+			{
+				condition alertedToEnemy
+				selector
+				{
+					decorator timer( 1000 )
+					{
+						selector
+						{
+							// defending reactor, or try to avoid being killed while healing (hence the different values)
+							// the isVisible check is here to prevent "defending" when enemies are detected by radars
+							condition ( ( distanceTo( E_H_REACTOR ) <= 300 || distanceTo( E_H_MEDISTAT ) <= 250 ) && isVisible( E_ENEMY ) )
+							{
+								action fight
+							}
+
+							sequence
+							{
+								condition ( healScore > 0.5 && percentHealth( E_GOAL ) > 0.3  && random > 0.3 )
+								condition baseRushScore < 0.75
+								selector
+								{
+									decorator timer( 3000 )
+									{
+										action heal
+									}
+									action roamInRadius( E_H_MEDISTAT, 250 )
+								}
+							}
+						}
+					}
+
+					sequence
+					{
+						//if goal is a close enough enemy building or if we're gonna die
+						condition ( percentHealth( E_SELF ) < 0.3 || ( distanceTo( E_GOAL ) < 400 && goalType == ET_BUILDABLE ) )
+						condition ( distanceTo( E_FRIENDLYBUILDING ) > 400 )
+						selector
+						{
+							// no need to check the upgrade is in inventory, since action would fail
+							action activateUpgrade( UP_FIREBOMB )
+							action activateUpgrade( UP_GRENADE )
+						}
+					}
+					action fight
+				}
+			}
+
+			selector
+			{
+				sequence
+				{
+					condition healScore > 0.25
+					selector
+					{
+						decorator timer( 3000 )
+						{
+							action heal
+						}
+						action roamInRadius( E_H_MEDISTAT, 250 )
+					}
+				}
+			}
+
+			sequence
+			{
+				condition ( distanceTo( E_H_ARMOURY ) < 500 )
+				action equip
+			}
+
+			action stayHere( 500 )
+			action roam
+		}
+
+	}
+
+	condition team == TEAM_ALIENS
+	{
+		selector
+		{
+			condition ( aliveTime > 1500 && healScore < 0.5 )
+			{
+				action evolve
+			}
+
+			sequence
+			{
+				condition alertedToEnemy
+				selector
+				{
+					decorator timer( 1000 )
+					{
+						selector
+						{
+							sequence
+							{
+								condition alertedToEnemy
+								condition ( distanceTo( E_A_OVERMIND ) <= 100 || distanceTo( E_A_BOOSTER ) <= 100 )
+								action fight
+							}
+							sequence
+							{
+								condition ( healScore > 0.5 && percentHealth( E_GOAL ) > 0.3  && random > 0.3 )
+								condition baseRushScore < 0.75
+								action heal
+							}
+						}
+					}
+
+					action fight
+				}
+			}
+
+			selector
+			{
+				sequence
+				{
+					condition healScore > 0.25
+					action heal
+				}
+			}
+
+			action stayHere( 500 )
+			action roam
+		}
+	}
+}


### PR DESCRIPTION
This adds three example behavior files for bots. They are reasonably well tested. My server currently uses nearly the same files, and Der Bunker server currently uses exactly these files.

What these files do:

- `follow.bt` makes a bot follow another player/bot. To make bot 1 follow player 2, use `/bot behavior 1 follow 2`. To make a bot on your team follow you while playing, use `/tactic follow 1`.
- `stay-here.bt` makes a bot stay near a specified point. To make bot 1 stay near point `(100, 200, 300)`, use `/bot behavior 1 stay-here 100 200 300`. To make a bot on your team stay where you currently are, use `/tactic stay-here 1`.
- `defend.bt` is a more elaborate version of `camper.bt`, handling things like human bots repairing or preventing damaging the own base.

There is some duplication. I am aware of that. But as these are config files, I think it is desirable to make them stand-alone.