### PR TITLE
Limit bot fill slider to safe values

### DIFF
--- a/ui/server_setup.rml
+++ b/ui/server_setup.rml
@@ -192,7 +192,7 @@
 					<h3><translate>Minimum bots per team</translate></h3>
 					<tooltip><translate>Fill teams until they have enough players</translate></tooltip>
 				</parent>
-				<input type="range" min="0" max="31" step="1" cvar="g_bot_defaultFill"/>
+				<input type="range" min="0" max="9" step="1" cvar="g_bot_defaultFill"/>
 				<p><inlinecvar cvar="g_bot_defaultFill" type="number" format="%g"/>&nbsp; <translate>bots</translate><ilink onclick='Events.pushevent("exec reset g_bot_defaultFill", event)'> (reset) </ilink></p>
 			</row>
 			<row>


### PR DESCRIPTION
9 is the maximum bots you can have per team without running out of slots given a solo player and the default sv_maxclients of 20.

Fixes https://github.com/Unvanquished/Unvanquished/issues/1812.